### PR TITLE
improve auditing

### DIFF
--- a/nbconvert_a11y/templates/a11y/components/audit.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/audit.html.j2
@@ -1,7 +1,31 @@
-{% from "a11y/components/core.html.j2" import dialog_close %}
+{# # in page auditing
+
+this template creates an in-page accessibility auditing dialog.
+the eventual state of a notebook is an interactive editing state.
+having the auditing system brings accessibility standards and knowledge
+nearer to the developer.
+it can be useful when authoring is enabled and when reporting issues
+or feedback.
+
+the axe tests are configurable in the dialog.
+when running axe tests, the dialog running the tests must be suppressed and
+reactivated after the tests complete.
+if the dialog remains open then axe will only test the dialog.
+
+#}
+
+{% from "a11y/components/core.html.j2" import dialog_close, multiselect %}
+{% set RULES = "wcag2a wcag2aa wcag2aaa wcag21a wcag21aa wcag22aa best-practice ACT section508 TTv5 EN-301-549
+experimental".split() %}
 <dialog id="nb-audit">
     <h1>AXE accessibility violations</h1>
-    {{dialog_close()}}
+    <form method="dialog">
+        {{dialog_close()}}
+    </form>
+    <form name="axe" method="post">
+        {{multiselect("axe-rules", RULES)}}
+        <button type="submit">audit</button>
+    </form>
     <table id="nb-audit-violations">
         <caption aria-live="polite"><span role="status" id="nb-audit-desc"></span></caption>
         <tbody>
@@ -28,20 +52,26 @@
 <script>
     const VIOLATION_TABLE = document.getElementById("nb-audit-violations"),
         VIOLATION_NODES_TABLE = document.getElementById("nb-audit-nodes"),
-        VIOLATION_COLS = ["id", "impact", "description", "help"];
-    async function auditNotebook() {
+        VIOLATION_COLS = ["id", "impact", "description", "help"],
+        AXE_DIALOG = document.getElementById("nb-audit");
+    function getRules() {
+        return Array.from(document.forms.axe.elements["axe-rules"].selectedOptions).map(x => x.value)
+    }
+    async function auditNotebook(show = false) {
         axe.reset()
         await axe.run({
             runOnly: {
                 type: 'tag',
-                values: ['wcag2a', 'wcag2aa', "wcag2aaa", "best-practice", "ACT"]
+                values: getRules()
             }
         }, (err, results) => {
+            show ? AXE_DIALOG.showModal() : null;
             updateAuditTables(results)
         })
     }
     function updateAuditTables(results) {
         var total = 0, violations = { "serious": 0, "critical": 0, "moderate": 0, "minor": 0 };
+        AXE_DIALOG.querySelectorAll("table tbody").forEach(x => x.replaceChildren());
         if (results.violations) {
             for (const x in results.violations) {
                 violations[results.violations[x].impact] = violations[results.violations[x].impact] + 1;
@@ -94,4 +124,9 @@
             return getCell(node.parentElement);
         }
     }
+    document.forms.axe.addEventListener("submit", (e) => {
+        e.preventDefault();
+        AXE_DIALOG.close()
+        auditNotebook(true);
+    })
 </script>

--- a/nbconvert_a11y/templates/a11y/components/core.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/core.html.j2
@@ -53,9 +53,31 @@
 <button formmethod="dialog">Close</button>
 {% endmacro %}
 
+{% macro dialog_close_form() %}
+<form>{{dialog_close()}}</form>
+{% endmacro %}
+
+
 {% macro h(level, title)%}
 {% set name="-".join(map(str.lower, title.split()))%}
 <h{{level}} id="nb-{{name}}-label">{{title}}</h{{level}}>
 {% endmacro%}
 
 {% macro hide(object) %}{% if object %} hidden{% endif %}{% endmacro %}
+
+{% macro multiselect(title, values={}, default=None) %}
+{% set name="-".join(map(str.lower, title.split()))%}
+{% if default == None %}
+{% set default = list(values) %}
+{% endif %}
+{% if isinstance(values, [].__class__) %}
+{% set values = dict(zip(values, values))%}
+{% endif %}
+<label>{{title}}
+    <select name="{{name}}" id="{{name}}-select" multiple>
+        {% for k, v in values.items() %}
+        <option value="{{v}}" {% if k in default %} selected{% endif %}>{{k}}</option>
+        {% endfor %}
+    </select>
+</label>
+{% endmacro %}

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -83,7 +83,7 @@ details.log:not([open])+table,
     width: 1px;
 }
 
-#nb-settings>form>* {
+dialog form>* {
     display: block;
 }
 


### PR DESCRIPTION
currently, the page audit is run when the page loads. the pages needs top to be reloaded to rerun the audit under different settings. 

this change makes it possible to rerun audits under different conditions. it adds widgets to choose the axe testing conditions. there are plenty of knobs that could be added to this interface. the current implementation is sufficient for interactively generating reports based on different settings.

 in-browser reporting doesn't make sense in read only documents. it would be a weird disclosure. reports are useful for formatting feedback reports and authoring accessibility conscious documents.