### PR TITLE
increase utility of dialogs by allowing them to be block elements

### DIFF
--- a/nbconvert_a11y/templates/a11y/base.html.j2
+++ b/nbconvert_a11y/templates/a11y/base.html.j2
@@ -52,15 +52,8 @@ the notebook experiennce from browse to edit/focus mode.
     {# skip to top is needed for long notebooks.
     it is difficult to access for keyboard users. #}
     <section id="nb-dialogs">
-        {% if resources.include_settings %}
-        <button onclick="openDialog()" aria-controls="nb-settings" accesskey=",">Settings</button>
-        {% endif %}
-        {% if resources.include_axe %}<button aria-controls="nb-audit" aria-describedby="nb-audit-desc"
-            onclick="openDialog()">audit</button>{% endif %}
-        {% if resources.include_help %}<button onclick="openDialog()" aria-controls="nb-help"
-            accesskey="?">help</button>{% endif %}
         <details>
-            <summary onclick="openDialogs()">expand all dialogs</summary>
+            <summary onclick="openDialogs()">settings, help, & diagnostics</summary>
         </details>
         <section>
             {% if resources.include_settings %}{% include "a11y/components/settings.html.j2" %}{% endif %}
@@ -68,6 +61,16 @@ the notebook experiennce from browse to edit/focus mode.
             {% if resources.include_help %}{% include "a11y/components/help.html.j2" %}{% endif %}
             {% if resources.include_axe %}{% include "a11y/components/audit.html.j2" %}{% endif %}
         </section>
+        {# make the individual settings discoverable before all the settings
+        when using shift+tab #}
+        {% if resources.include_settings %}
+        <button onclick="openDialog()" aria-controls="nb-settings" accesskey=",">settings</button>
+        {% endif %}
+        <button aria-controls="nb-visibility-dialog" onclick="openDialog()" accesskey="-">show/hide</button>
+        {% if resources.include_axe %}<button aria-controls="nb-audit" aria-describedby="nb-audit-desc"
+            onclick="openDialog()">audit</button>{% endif %}
+        {% if resources.include_help %}<button onclick="openDialog()" aria-controls="nb-help"
+            accesskey="?">help</button>{% endif %}
     </section>
     <footer>
         {{activity_log()}}

--- a/nbconvert_a11y/templates/a11y/base.html.j2
+++ b/nbconvert_a11y/templates/a11y/base.html.j2
@@ -55,12 +55,10 @@ the notebook experiennce from browse to edit/focus mode.
         <details>
             <summary onclick="openDialogs()">settings, help, & diagnostics</summary>
         </details>
-        <section>
-            {% if resources.include_settings %}{% include "a11y/components/settings.html.j2" %}{% endif %}
-            {% include "a11y/components/visibility.html.j2"%}
-            {% if resources.include_help %}{% include "a11y/components/help.html.j2" %}{% endif %}
-            {% if resources.include_axe %}{% include "a11y/components/audit.html.j2" %}{% endif %}
-        </section>
+        {% if resources.include_settings %}{% include "a11y/components/settings.html.j2" %}{% endif %}
+        {% include "a11y/components/visibility.html.j2"%}
+        {% if resources.include_help %}{% include "a11y/components/help.html.j2" %}{% endif %}
+        {% if resources.include_axe %}{% include "a11y/components/audit.html.j2" %}{% endif %}
         {# make the individual settings discoverable before all the settings
         when using shift+tab #}
         {% if resources.include_settings %}

--- a/nbconvert_a11y/templates/a11y/base.html.j2
+++ b/nbconvert_a11y/templates/a11y/base.html.j2
@@ -51,19 +51,49 @@ the notebook experiennce from browse to edit/focus mode.
     add features like run time computation. #}
     {# skip to top is needed for long notebooks.
     it is difficult to access for keyboard users. #}
-    <footer>
-        {% if resources.include_settings %}{% include "a11y/components/settings.html.j2" %}{% endif %}
+    <footer id="nb-dialogs">
+        {% if resources.include_settings %}
+        <button onclick="openDialog()" aria-controls="nb-settings" accesskey=",">Settings</button>
+        {% endif %}
         {% if resources.include_axe %}<button aria-controls="nb-audit" aria-describedby="nb-audit-desc"
             onclick="openDialog()">audit</button>{% endif %}
         {% if resources.include_help %}<button onclick="openDialog()" aria-controls="nb-help"
             accesskey="?">help</button>{% endif %}
+        <details>
+            <summary onclick="openDialogs()">expand all dialogs</summary>
+        </details>
+        <section>
+            {% if resources.include_settings %}{% include "a11y/components/settings.html.j2" %}{% endif %}
+            {% include "a11y/components/visibility.html.j2"%}
+            {% if resources.include_help %}{% include "a11y/components/help.html.j2" %}{% endif %}
+            {% if resources.include_axe %}{% include "a11y/components/audit.html.j2" %}{% endif %}
+        </section>
+        <style>
+            #nb-dialogs details[open]+section {
+                display: flex;
+                flex-direction: column;
+            }
+
+            #nb-dialogs details[open]+section dialog {
+                position: relative;
+            }
+        </style>
+    </footer>
+    <footer>
         {{activity_log()}}
         <a href="#TOP" accesskey="0">skip to top</a>
     </footer>
-    {% if resources.include_help %}{% include "a11y/components/help.html.j2" %}{% endif %}
-    {% if resources.include_axe %}{% include "a11y/components/audit.html.j2" %}{% endif %}
-    {% include "a11y/components/visibility.html.j2"%}
 </body>
+<script>
+    function openDialogs() {
+        let trigger = document.querySelector("#nb-dialogs > details");
+        document.querySelectorAll("#nb-dialogs dialog:not(.log)").forEach(
+            x => {
+                trigger.getAttribute("open") === null ? x.show() : x.close();
+            }
+        )
+    }
+</script>
 {% endblock body_footer %}
 
 {% block footer_js %}

--- a/nbconvert_a11y/templates/a11y/base.html.j2
+++ b/nbconvert_a11y/templates/a11y/base.html.j2
@@ -87,11 +87,13 @@ the notebook experiennce from browse to edit/focus mode.
 <script>
     function openDialogs() {
         let trigger = document.querySelector("#nb-dialogs > details");
-        document.querySelectorAll("#nb-dialogs dialog:not(.log)").forEach(
+        Array.from(
+            document.querySelectorAll("#nb-dialogs dialog:not(.log)")
+        ).reverse().forEach(
             x => {
                 trigger.getAttribute("open") === null ? x.show() : x.close();
             }
-        )
+        );
     }
 </script>
 {% endblock body_footer %}

--- a/nbconvert_a11y/templates/a11y/base.html.j2
+++ b/nbconvert_a11y/templates/a11y/base.html.j2
@@ -94,6 +94,7 @@ the notebook experiennce from browse to edit/focus mode.
                 trigger.getAttribute("open") === null ? x.show() : x.close();
             }
         );
+        event.target.focus();
     }
 </script>
 {% endblock body_footer %}

--- a/nbconvert_a11y/templates/a11y/base.html.j2
+++ b/nbconvert_a11y/templates/a11y/base.html.j2
@@ -51,7 +51,7 @@ the notebook experiennce from browse to edit/focus mode.
     add features like run time computation. #}
     {# skip to top is needed for long notebooks.
     it is difficult to access for keyboard users. #}
-    <footer id="nb-dialogs">
+    <section id="nb-dialogs">
         {% if resources.include_settings %}
         <button onclick="openDialog()" aria-controls="nb-settings" accesskey=",">Settings</button>
         {% endif %}
@@ -68,17 +68,7 @@ the notebook experiennce from browse to edit/focus mode.
             {% if resources.include_help %}{% include "a11y/components/help.html.j2" %}{% endif %}
             {% if resources.include_axe %}{% include "a11y/components/audit.html.j2" %}{% endif %}
         </section>
-        <style>
-            #nb-dialogs details[open]+section {
-                display: flex;
-                flex-direction: column;
-            }
-
-            #nb-dialogs details[open]+section dialog {
-                position: relative;
-            }
-        </style>
-    </footer>
+    </section>
     <footer>
         {{activity_log()}}
         <a href="#TOP" accesskey="0">skip to top</a>

--- a/nbconvert_a11y/templates/a11y/components/nb-toolbar.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/nb-toolbar.html.j2
@@ -1,6 +1,5 @@
 <form name="notebook" id="notebook" aria-labelledby="nb-notebook-label">
     <label><input id="nb-edit-mode" type="checkbox" name="edit">edit mode</label>
     <button aria-controls="nb-metadata" onclick="openDialog()">metadata</button>
-    <button aria-controls="nb-visibility-dialog" onclick="openDialog()" accesskey="-">show/hide</button>
     <button type="submit">Run</button>
 </form>

--- a/nbconvert_a11y/templates/a11y/components/settings.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/settings.html.j2
@@ -4,7 +4,6 @@ settings provides multiple screen reader navigation techniques when the dialog i
 #}
 
 {% from "a11y/components/core.html.j2" import h, radiogroup, select, activity_log, input_number, checkbox, dialog_close %}
-<button onclick="openDialog()" aria-controls="nb-settings" accesskey=",">Settings</button>
 <dialog id="nb-settings">
     <form name="settings">
         {{h(1, "accessibility settings")}}

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -72,6 +72,7 @@ textarea[name=source] {
     box-shadow: 0 0 0 calc(2 * max(var(--nb-focus-width), 1px));
 }
 
+#nb-dialogs details:not([open])+section > dialog:not([open]):not(:focus-within):not(:active),
 legend:not(:focus-within):not(:active),
 details.log:not([open])+table,
 .visually-hidden:not(:focus-within):not(:active) {

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -72,7 +72,17 @@ textarea[name=source] {
     box-shadow: 0 0 0 calc(2 * max(var(--nb-focus-width), 1px));
 }
 
-#nb-dialogs details:not([open])+section > dialog:not([open]):not(:focus-within):not(:active),
+#nb-dialogs details[open]+section {
+    display: flex;
+    flex-direction: column;
+}
+
+#nb-dialogs details[open]+section dialog {
+    position: relative;
+}
+
+
+#nb-dialogs details:not([open])+section>dialog:not([open]):not(:focus-within):not(:active),
 legend:not(:focus-within):not(:active),
 details.log:not([open])+table,
 .visually-hidden:not(:focus-within):not(:active) {

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -72,17 +72,12 @@ textarea[name=source] {
     box-shadow: 0 0 0 calc(2 * max(var(--nb-focus-width), 1px));
 }
 
-#nb-dialogs details[open]+section {
-    display: flex;
-    flex-direction: column;
-}
-
-#nb-dialogs details[open]+section dialog {
+#nb-dialogs details[open]~dialog {
     position: relative;
 }
 
 
-#nb-dialogs details:not([open])+section>dialog:not([open]):not(:focus-within):not(:active),
+#nb-dialogs details:not([open])~dialog:not([open]):not(:focus-within):not(:active),
 legend:not(:focus-within):not(:active),
 details.log:not([open])+table,
 .visually-hidden:not(:focus-within):not(:active) {


### PR DESCRIPTION
this pull request tied up some questions i had about the placement about the dialog buttons.

we take advantage of the modal and block natural of `dialog` tags. we've been using `dialog`s for settings and help, things that should be optionally accessible. we add a new feature that expands the `dialog`s in their block position to optionally provide all of the modal content and scrollable block content.