### PR TITLE
use the conda forge implementation on the vnu-validator

### DIFF
--- a/.github/test-environment.yml
+++ b/.github/test-environment.yml
@@ -29,3 +29,4 @@ dependencies:
   - doit
   - mkdocs-material
   - mkdocstrings[python]
+  - vnu-validator

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
           playwright install --with-deps chromium
       - name: init node & files
         run: |
-          npm install vnu-jar axe-core
+          npm install axe-core
           doit copy
       - name: init dev module
         run: |

--- a/tests/test_w3c.py
+++ b/tests/test_w3c.py
@@ -13,7 +13,13 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from json import dumps
+from logging import getLogger
+from pathlib import Path
+
 import exceptiongroup
+from pytest import mark, param
+
 
 from tests.test_smoke import CONFIGURATIONS, get_target_html
 
@@ -21,15 +27,13 @@ EXCLUDE = re.compile(
     """or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.$"""
     # https://github.com/validator/validator/issues/1125
 )
-
-
 VNU = shutil.which("vnu") or shutil.which("vnu.cmd")
 
 
 def validate_html(*files: pathlib.Path) -> dict:
     return json.loads(
         subprocess.check_output(
-            shlex.split(f"{VNU} --stdout --format json --exit-zero-always") + list(files)
+            [VNU, "--stdout", "--format=json", "--exit-zero-always",  *files]
         ).decode()
     )
 
@@ -57,13 +61,6 @@ def raise_if_errors(results, exclude=EXCLUDE):
     if exceptions:
         raise exceptiongroup.ExceptionGroup("nu validator errors", exceptions)
 
-
-from json import dumps
-from logging import getLogger
-from pathlib import Path
-
-import exceptiongroup
-from pytest import mark, param
 
 HERE = Path(__file__).parent
 NOTEBOOKS = HERE / "notebooks"

--- a/tests/test_w3c.py
+++ b/tests/test_w3c.py
@@ -6,20 +6,17 @@ import functools
 import itertools
 import json
 import operator
-import os
 import pathlib
 import re
 import shlex
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 import exceptiongroup
 
 from tests.test_smoke import CONFIGURATIONS, get_target_html
 
-WIN = os.name == "nt"
 EXCLUDE = re.compile(
     """or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.$"""
     # https://github.com/validator/validator/issues/1125
@@ -27,15 +24,12 @@ EXCLUDE = re.compile(
 
 
 VNU = shutil.which("vnu") or shutil.which("vnu.cmd")
-JAVA = Path(shutil.which("java") or shutil.which("java.exe"))
-JAR = Path(sys.prefix) / ("Library/lib" if WIN else "lib") / "vnu.jar"
 
 
 def validate_html(*files: pathlib.Path) -> dict:
     return json.loads(
         subprocess.check_output(
-            shlex.split(f"{JAVA} -jar {JAR} --stdout --format json --exit-zero-always")
-            + list(files)
+            shlex.split(f"{VNU} --stdout --format json --exit-zero-always") + list(files)
         ).decode()
     )
 

--- a/tests/test_w3c.py
+++ b/tests/test_w3c.py
@@ -33,7 +33,7 @@ VNU = shutil.which("vnu") or shutil.which("vnu.cmd")
 def validate_html(*files: pathlib.Path) -> dict:
     return json.loads(
         subprocess.check_output(
-            [VNU, "--stdout", "--format=json", "--exit-zero-always",  *files]
+            [VNU, "--stdout", "--format", "json", "--exit-zero-always",  *files]
         ).decode()
     )
 

--- a/tests/test_w3c.py
+++ b/tests/test_w3c.py
@@ -6,35 +6,35 @@ import functools
 import itertools
 import json
 import operator
+import os
 import pathlib
 import re
 import shlex
+import shutil
 import subprocess
+import sys
+from pathlib import Path
 
 import exceptiongroup
 
 from tests.test_smoke import CONFIGURATIONS, get_target_html
 
+WIN = os.name == "nt"
 EXCLUDE = re.compile(
     """or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.$"""
     # https://github.com/validator/validator/issues/1125
 )
 
 
-@functools.lru_cache(1)
-def vnu_jar():
-    VNU_JAR = (
-        pathlib.Path(subprocess.check_output(shlex.split("npm root vnu-jar")).strip().decode())
-        / "vnu-jar/build/dist/vnu.jar"
-    )
-    assert VNU_JAR.exists()
-    return VNU_JAR
+VNU = shutil.which("vnu") or shutil.which("vnu.cmd")
+JAVA = Path(shutil.which("java") or shutil.which("java.exe"))
+JAR = Path(sys.prefix) / ("Library/lib" if WIN else "lib") / "vnu.jar"
 
 
 def validate_html(*files: pathlib.Path) -> dict:
     return json.loads(
         subprocess.check_output(
-            shlex.split(f"java -jar {vnu_jar()} --stdout --format json --exit-zero-always")
+            shlex.split(f"{JAVA} -jar {JAR} --stdout --format json --exit-zero-always")
             + list(files)
         ).decode()
     )


### PR DESCRIPTION
@bollwyvl created a [feedstock for the w3c vnu validator](https://github.com/conda-forge/vnu-validator-feedstock). this pull request integrates that effort instead of the hand rolled installation we use now.

lets have this PR only focus on CI and i'll make another PR that creates a pytest fixture for the validator assuming `vnu-validator` is installed with conda.

ref: https://github.com/conda-forge/staged-recipes/pull/24509