### PR TITLE
add a quick test for flask dev tools accessibility issues

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,12 @@ def make_app():
         e = get_exporter(exporter)(**params)
         return e.from_filename(NOTEBOOKS / name)[0]
 
+    @app.route("/bad")
+    def bad():
+        if request.query_string:
+            assert False, "this causes a flask failure when the query string is non empty"
+        return ""
+
     return app
 
 

--- a/tests/test_third.py
+++ b/tests/test_third.py
@@ -4,42 +4,23 @@ these tests allow us to track ongoing community progress and record inaccessibil
 upstream of our control.
 """
 
-from functools import partial
 from os import environ
 from unittest import TestCase
 from flask import url_for
 
 import pytest
-from pytest import fixture, mark, skip
+from pytest import fixture, skip
 
-from nbconvert import get_exporter
 from nbconvert_a11y.pytest_axe import (
     JUPYTER_WIDGETS,
     NO_ALT,
     PYGMENTS,
     SA11Y,
-    AllOf,
     Violation,
 )
-from tests.test_color_themes import LORENZ
 
 # only run these tests when the CI environment variables are defined.
 environ.get("CI") or skip(allow_module_level=True)
-xfail = partial(mark.xfail, raises=AllOf, strict=True)
-
-
-@fixture()
-def exporter(request):
-    e = get_exporter("html")()
-    return e
-
-
-@fixture()
-def a11y_exporter(request):
-    e = get_exporter("a11y")()
-    e.wcag_priority = "AA"
-    e.include_sa11y = True
-    return e
 
 
 class DefaultTemplate(TestCase):


### PR DESCRIPTION
axe was catching errors on the `flask` debug templates when i was adding the live server fixture. the pull request codifies those inaccessibilities.

`flask` is often used computational literacy efforts and app development should be equitable to assistive tech users. 

it is turning out that this library is quiet good at error tracking of third party upstreams.