### PR TITLE
prompt improvement

### DIFF
--- a/nbconvert_a11y/exporter.py
+++ b/nbconvert_a11y/exporter.py
@@ -94,10 +94,10 @@ class A11yExporter(PostProcess, HTMLExporter):
         config=True
     )
     # TF: id love for these definitions to have their own parent class.
-    prompt_in = CUnicode("In")
-    prompt_out = CUnicode("Out")
-    prompt_left = CUnicode("[")
-    prompt_right = CUnicode("]")
+    prompt_in = CUnicode("In").tag(config=True)
+    prompt_out = CUnicode("Out").tag(config=True)
+    prompt_left = CUnicode("[").tag(config=True)
+    prompt_right = CUnicode("]").tag(config=True)
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/nbconvert_a11y/exporter.py
+++ b/nbconvert_a11y/exporter.py
@@ -94,8 +94,8 @@ class A11yExporter(PostProcess, HTMLExporter):
         config=True
     )
     # TF: id love for these definitions to have their own parent class.
-    prompt_input = CUnicode("In")
-    prompt_output = CUnicode("Out")
+    prompt_in = CUnicode("In")
+    prompt_out = CUnicode("Out")
     prompt_left = CUnicode("[")
     prompt_right = CUnicode("]")
 
@@ -145,8 +145,8 @@ class A11yExporter(PostProcess, HTMLExporter):
         resources["code_theme"] = THEMES[self.code_theme]
         resources["axe_url"] = self.axe_url
         resources["include_sa11y"] = self.include_sa11y
-        resources["prompt_input"] = self.prompt_input
-        resources["prompt_output"] = self.prompt_output
+        resources["prompt_in"] = self.prompt_in
+        resources["prompt_out"] = self.prompt_out
         resources["prompt_left"] = self.prompt_left
         resources["prompt_right"] = self.prompt_right
 

--- a/nbconvert_a11y/exporter.py
+++ b/nbconvert_a11y/exporter.py
@@ -239,8 +239,10 @@ def mdtoc(html):
         id = header.attrs.get("id")
         if not id:
             from slugify import slugify
-
-            id = slugify(header.string)
+            if header.string:
+                id = slugify(header.string)
+            else:
+                continue
 
         # there is missing logistics for managely role=heading
         # adding code group semantics will motivate this addition
@@ -261,8 +263,10 @@ def heading_links(html):
         id = header.attrs.get("id")
         if not id:
             from slugify import slugify
-
-            id = slugify(header.string)
+            if header.string:
+                id = slugify(header.string)
+            else:
+                continue
 
         link = soupify(f"""<a href="#{id}">{header.string}</a>""").body.a
         header.clear()

--- a/nbconvert_a11y/exporter.py
+++ b/nbconvert_a11y/exporter.py
@@ -93,6 +93,11 @@ class A11yExporter(PostProcess, HTMLExporter):
     code_theme = Enum(list(THEMES), "gh-high", help="an accessible pygments dark/light theme").tag(
         config=True
     )
+    # TF: id love for these definitions to have their own parent class.
+    prompt_input = CUnicode("In")
+    prompt_output = CUnicode("Out")
+    prompt_left = CUnicode("[")
+    prompt_right = CUnicode("]")
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -127,6 +132,7 @@ class A11yExporter(PostProcess, HTMLExporter):
         return c
 
     def from_notebook_node(self, nb, resources=None, **kw):
+        # this is trash and needs serious fixing
         resources = resources or {}
         resources["include_axe"] = self.include_axe
         resources["include_settings"] = self.include_settings
@@ -139,6 +145,10 @@ class A11yExporter(PostProcess, HTMLExporter):
         resources["code_theme"] = THEMES[self.code_theme]
         resources["axe_url"] = self.axe_url
         resources["include_sa11y"] = self.include_sa11y
+        resources["prompt_input"] = self.prompt_input
+        resources["prompt_output"] = self.prompt_output
+        resources["prompt_left"] = self.prompt_left
+        resources["prompt_right"] = self.prompt_right
 
         return super().from_notebook_node(nb, resources, **kw)
 

--- a/nbconvert_a11y/templates/a11y/components/cell.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/cell.html.j2
@@ -30,18 +30,16 @@ that would include talking to the kernel. #}
 {% endmacro %}
 
 {% macro cell_execution_count(i, execution_count, hidden=False) %}
-<output form="cell-{{i}}" name="execution_count" id="cell-{{i}}-execution_count"
-    {{hide(hidden)}}>#{{execution_count}}</output>
-{% endmacro %}
-
-
-{% macro cell_source(i, source, cell_type, execution_count, hidden=False) %}
 <label id="cell-{{i}}-source-label">
     <span>{{resources.prompt_in}}</span>
     <span aria-hidden="true">{{resources.prompt_left}}</span>
     <span>{{execution_count}}</span>
     <span aria-hidden="true">{{resources.prompt_right}}</span>
 </label>
+{% endmacro %}
+
+
+{% macro cell_source(i, source, cell_type, execution_count, hidden=False) %}
 <textarea form="cell-{{i}}" id="cell-{{i}}-source" name="source" rows="{{source.splitlines().__len__()}}"
     aria-labelledby="cell-{{i}}-source-label nb-source-label" readonly>{{source}}</textarea>
 <div role="group" aria-labelledby="nb-source-label">
@@ -72,7 +70,7 @@ that would include talking to the kernel. #}
 {# the following span should get its own column in the table #}
 <fieldset {{hide(hidden)}} data-outputs="{{outputs.__len__()}}">
     <legend id="cell-{{i}}-outputs-label" aria-describedby="nb-outputs-desc">
-        <span>{{resources.prompt_output}}</span>
+        <span>{{resources.prompt_out}}</span>
         <span aria-hidden="true">{{resources.prompt_left}}</span>
         <span>{{execution_count}}</span>
         <span aria-hidden="true">{{resources.prompt_right}}</span>

--- a/nbconvert_a11y/templates/a11y/components/cell.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/cell.html.j2
@@ -36,21 +36,15 @@ that would include talking to the kernel. #}
 
 
 {% macro cell_source(i, source, cell_type, execution_count, hidden=False) %}
-{% set label -%}
-<span id="cell-{{i}}-source-label">
-    <span class="cell-prompt-in">
-        <span class="cell-prompt-left" aria-hidden="true"><span></span></span>
-        <span>{{execution_count}}</span>
-        <span class="cell-prompt-right" aria-hidden="true"><span></span></span>
-    </span>
-</span>
-{%- endset %}
-<details open aria-labelledby="cell-{{i}}-source-label" {{hide(hidden)}}>
-    <summary inert>{{label}}</summary>
-    <textarea form="cell-{{i}}" id="cell-{{i}}-source" name="source" rows="{{source.splitlines().__len__()}}"
-        aria-labelledby="cell-{{i}}-source-label nb-source-label" readonly>{{source}}</textarea>
-    {{highlight(source, cell_type)}}
-</details>
+<label for="cell-{{i}}-source">
+    <span>In</span>
+    <span aria-hidden="true">[</span>
+    <span>{{execution_count}}</span>
+    <span aria-hidden="true">]</span>
+</label>
+<textarea form="cell-{{i}}" id="cell-{{i}}-source" name="source" rows="{{source.splitlines().__len__()}}"
+    aria-labelledby="cell-{{i}}-source-label nb-source-label" readonly>{{source}}</textarea>
+{{highlight(source, cell_type)}}
 {% endmacro %}
 
 {% macro cell_metadata(i, metadata, hidden=False) %}
@@ -68,28 +62,30 @@ that would include talking to the kernel. #}
 
 {%- macro cell_output(i, cell, source, outputs, cell_type, execution_count, hidden=False) -%}
 {% set CODE = cell_type == "code" %}
-{% set label %}{% if CODE and outputs %}
-<span class="cell-prompt-out">
-    <span class="cell-prompt-left" aria-hidden="true"><span></span></span>
-    <span>{{execution_count}}</span>
-    <span class="cell-prompt-right" aria-hidden="true"><span></span></span>
-</span>
-{% else %}Cell {{i}}{% endif %}{% endset %}
-<span hidden id="cell-{{i}}-outputs-len">{{outputs.__len__()}} outputs</span>
-{% if CODE and outputs %}
-{% if outputs %}
-<details open aria-labelledby="cell-{{i}}-outputs-label" {{hide(hidden)}}>
-    <summary inert id="cell-{{i}}-outputs-label" aria-describedby="nb-outputs-desc">{{label}}</summary>
+{% if CODE %}
+{% if not outputs %}
+<span class="visually-hidden" id="cell-{{i}}-outputs-len">In {{execution_count}} has {{outputs.__len__()}}
+    outputs.</span>
+{% else %}
+{# the following span should get its own column in the table #}
+<fieldset {{hide(hidden)}} data-outputs="{{outputs.__len__()}}">
+    <legend id="cell-{{i}}-outputs-label" aria-describedby="nb-outputs-desc">
+        <span>Out</span>
+        <span aria-hidden="true">[</span>
+        <span>{{execution_count}}</span>
+        <span aria-hidden="true">]</span>
+    </legend>
+    <span class="visually-hidden" id="cell-{{i}}-outputs-len">has {{outputs.__len__()}} output{% if outputs.__len__()>1
+        %}s{% endif %}</span>
+    {% if outputs %}
     {# the output description should mention the number of outputs
     saying zero outputs should be an option. a cell without an output is probably a violation. #}
     {{cell_display_priority(i, outputs, cell)}}
-</details>
+    {% endif %}
+</fieldset>
 {% endif %}
-{% elif cell_type=="markdown" %}
-<details open aria-labelledby="cell-{{i}}-outputs-label" {{hide(hidden)}}>
-    <summary hidden inert id="cell-{{i}}-outputs-label">{{label}}</summary>
-    {{ markdown(source) | strip_files_prefix }}
-</details>
+{% else %}
+{{ markdown(source) | strip_files_prefix }}
 {% endif %}
 {%- endmacro -%}
 

--- a/nbconvert_a11y/templates/a11y/components/cell.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/cell.html.j2
@@ -37,14 +37,16 @@ that would include talking to the kernel. #}
 
 {% macro cell_source(i, source, cell_type, execution_count, hidden=False) %}
 <label id="cell-{{i}}-source-label">
-    <span>In</span>
-    <span aria-hidden="true">[</span>
+    <span>{{resources.prompt_in}}</span>
+    <span aria-hidden="true">{{resources.prompt_left}}</span>
     <span>{{execution_count}}</span>
-    <span aria-hidden="true">]</span>
+    <span aria-hidden="true">{{resources.prompt_right}}</span>
 </label>
 <textarea form="cell-{{i}}" id="cell-{{i}}-source" name="source" rows="{{source.splitlines().__len__()}}"
     aria-labelledby="cell-{{i}}-source-label nb-source-label" readonly>{{source}}</textarea>
-{{highlight(source, cell_type)}}
+<div role="group" aria-labelledby="nb-source-label">
+    {{highlight(source, cell_type)}}
+</div>
 {% endmacro %}
 
 {% macro cell_metadata(i, metadata, hidden=False) %}
@@ -70,10 +72,10 @@ that would include talking to the kernel. #}
 {# the following span should get its own column in the table #}
 <fieldset {{hide(hidden)}} data-outputs="{{outputs.__len__()}}">
     <legend id="cell-{{i}}-outputs-label" aria-describedby="nb-outputs-desc">
-        <span>Out</span>
-        <span aria-hidden="true">[</span>
+        <span>{{resources.prompt_output}}</span>
+        <span aria-hidden="true">{{resources.prompt_left}}</span>
         <span>{{execution_count}}</span>
-        <span aria-hidden="true">]</span>
+        <span aria-hidden="true">{{resources.prompt_right}}</span>
     </legend>
     <span class="visually-hidden" id="cell-{{i}}-outputs-len">has {{outputs.__len__()}} output{% if outputs.__len__()>1
         %}s{% endif %}</span>

--- a/nbconvert_a11y/templates/a11y/components/cell.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/cell.html.j2
@@ -36,7 +36,7 @@ that would include talking to the kernel. #}
 
 
 {% macro cell_source(i, source, cell_type, execution_count, hidden=False) %}
-<label for="cell-{{i}}-source">
+<label id="cell-{{i}}-source-label">
     <span>In</span>
     <span aria-hidden="true">[</span>
     <span>{{execution_count}}</span>

--- a/nbconvert_a11y/templates/a11y/components/cell.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/cell.html.j2
@@ -38,7 +38,11 @@ that would include talking to the kernel. #}
 {% macro cell_source(i, source, cell_type, execution_count, hidden=False) %}
 {% set label -%}
 <span id="cell-{{i}}-source-label">
-    <span>In</span><span aria-hidden="true">[</span><span>{{execution_count}}</span><span aria-hidden="true">]</span>
+    <span class="cell-prompt-in">
+        <span class="cell-prompt-left" aria-hidden="true"><span></span></span>
+        <span>{{execution_count}}</span>
+        <span class="cell-prompt-right" aria-hidden="true"><span></span></span>
+    </span>
 </span>
 {%- endset %}
 <details open aria-labelledby="cell-{{i}}-source-label" {{hide(hidden)}}>
@@ -64,8 +68,13 @@ that would include talking to the kernel. #}
 
 {%- macro cell_output(i, cell, source, outputs, cell_type, execution_count, hidden=False) -%}
 {% set CODE = cell_type == "code" %}
-{% set label %}{% if CODE and outputs %}Out<span aria-hidden="true">[</span>{{execution_count}}<span
-    aria-hidden="true">]</span>{% else %}Cell {{i}}{% endif %}{% endset %}
+{% set label %}{% if CODE and outputs %}
+<span class="cell-prompt-out">
+    <span class="cell-prompt-left" aria-hidden="true"><span></span></span>
+    <span>{{execution_count}}</span>
+    <span class="cell-prompt-right" aria-hidden="true"><span></span></span>
+</span>
+{% else %}Cell {{i}}{% endif %}{% endset %}
 <span hidden id="cell-{{i}}-outputs-len">{{outputs.__len__()}} outputs</span>
 {% if CODE and outputs %}
 {% if outputs %}

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -8,6 +8,27 @@
     --nb-font-size: 16px;
     --nb-font-family: serif;
     --nb-line-height: 1.5;
+    --nb-prompt-input: "In";
+    --nb-prompt-output: "Out";
+    --nb-prompt-left: "[";
+    --nb-prompt-right: "]";
+}
+
+
+.cell-prompt-in > .cell-prompt-left:before {
+    content: var(--nb-prompt-input);
+}
+
+.cell-prompt-out > .cell-prompt-left:before {
+    content: var(--nb-prompt-output);
+}
+
+.cell-prompt-left > span:before {
+    content: var(--nb-prompt-left);
+}
+
+.cell-prompt-right > span:after {
+    content: var(--nb-prompt-right);
 }
 
 body {

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -123,6 +123,7 @@ dialog form>* {
     display: none;
 }
 
-fieldset[data-outputs="0"] {
+fieldset[data-outputs="0"],
+.markdown > .nb-execution_count {
     display: none;
 }

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -8,28 +8,8 @@
     --nb-font-size: 16px;
     --nb-font-family: serif;
     --nb-line-height: 1.5;
-    --nb-prompt-input: "In";
-    --nb-prompt-output: "Out";
-    --nb-prompt-left: "[";
-    --nb-prompt-right: "]";
 }
 
-
-.cell-prompt-in > .cell-prompt-left:before {
-    content: var(--nb-prompt-input);
-}
-
-.cell-prompt-out > .cell-prompt-left:before {
-    content: var(--nb-prompt-output);
-}
-
-.cell-prompt-left > span:before {
-    content: var(--nb-prompt-left);
-}
-
-.cell-prompt-right > span:after {
-    content: var(--nb-prompt-right);
-}
 
 body {
     font-size: var(--nb-font-size);
@@ -99,7 +79,7 @@ textarea[name=source] {
 
 
 #nb-dialogs details:not([open])~dialog:not([open]):not(:focus-within):not(:active),
-legend:not(:focus-within):not(:active),
+/* legend:not(:focus-within):not(:active), */
 details.log:not([open])+table,
 .visually-hidden:not(:focus-within):not(:active) {
     clip: rect(0 0 0 0);
@@ -137,9 +117,12 @@ dialog form>* {
     font-size: max(44px, var(--nb-font-size));
 }
 
-.wcag-a details>summary[inert]~textarea[name=source],
-.wcag-aa details>summary[inert]~textarea[name=source],
-.wcag-aaa details>summary[inert]~textarea[name=source]~*,
-details>summary:not([inert])~textarea[name=source]~* {
+.wcag-a textarea[name=source],
+.wcag-aa textarea[name=source],
+.wcag-aaa textarea[name=source]~* {
+    display: none;
+}
+
+fieldset[data-outputs="0"] {
     display: none;
 }

--- a/nbconvert_a11y/templates/a11y/table.html.j2
+++ b/nbconvert_a11y/templates/a11y/table.html.j2
@@ -11,7 +11,7 @@ cell_form, cell_source, cell_metadata, cell_output with context%}
     data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %} {% endif %}
     data-index="{{loop.index}}">
     <td role="none" class="nb-anchor">{{cell_anchor(loop.index, cell.cell_type)}}</td>
-    <td role="none" class="nb-execution_count" hidden>{{cell_execution_count(loop.index, cell.execution_count)}}
+    <td role="none" class="nb-execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}
     </td>
     <td role="none" class="nb-cell_type" hidden>{{cell_cell_type(loop.index, cell.cell_type)}}</td>
     <td role="none" class="nb-toolbar" hidden>{{cell_form(loop.index)}}</td>

--- a/nbconvert_a11y/templates/a11y/table.html.j2
+++ b/nbconvert_a11y/templates/a11y/table.html.j2
@@ -11,7 +11,8 @@ cell_form, cell_source, cell_metadata, cell_output with context%}
     data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %} {% endif %}
     data-index="{{loop.index}}">
     <td role="none" class="nb-anchor">{{cell_anchor(loop.index, cell.cell_type)}}</td>
-    <td role="none" class="nb-execution_count">{{cell_execution_count(loop.index, cell.execution_count)}}
+    <td role="none" class="nb-execution_count" {{hide(cell.cell_type=="markdown" or cell.execution_count==None)}}>
+        {{cell_execution_count(loop.index, cell.execution_count)}}
     </td>
     <td role="none" class="nb-cell_type" hidden>{{cell_cell_type(loop.index, cell.cell_type)}}</td>
     <td role="none" class="nb-toolbar" hidden>{{cell_form(loop.index)}}</td>
@@ -66,7 +67,6 @@ cell_form, cell_source, cell_metadata, cell_output with context%}
             <td class="nb-toolbar"></td>
             <td class="nb-metadata">{# list keys #}</td>
             <td class="nb-loc">{{count_loc(nb)}}</td>
-
         </tr>
         <tr class="code">
             <th scope="row">code cells</th>

--- a/nbconvert_a11y/templates/a11y/table.html.j2
+++ b/nbconvert_a11y/templates/a11y/table.html.j2
@@ -38,7 +38,7 @@ cell_form, cell_source, cell_metadata, cell_output with context%}
 {% block body_loop %}
 {# the most consistent implementation would connect the input visibility to a form #}
 <table id="cells" role="presentation">
-    <tbody role="list">
+    <tbody role="list" aria-labelledby="nb-notebook-label nb-cells-label">
         <tr hidden>
             {% for col in COLUMNS %}
             <th scope="col">{{col}}</th>


### PR DESCRIPTION
the input and output prompts need to be testing to understand the best experience for screen readers and assistive technology. since we still need to test this feature then everything needs to be configurable.

the input and output prompts are legacy features in the jupyter notebook. their text form is meant to mimic code that could be used to access the values. `In[20]` could be used as an expression to retrieve the 20th input from a list of imports; this is similar to `Out[20]` which retrieves the 20th output from a dictionary if it exists. In/Out are short hand for Input/Output and would like need access to internationalization the similarity in the prompt's itemgetter forms allows readers to visually acknowledge that indeed an input and output correspond. ultimately, our notebook implementation should make this distinction semantically. these In/Out patterns are found in nearly all linear notebook implementations which is anything based on the notebook server model. observable notebooks that obey topological ordering don't have ordinal prompts rather they have nominal prompts.

the goal of the templates we are working on is to set the baseline accessible reading state for notebooks. then progressive enhancements would transform the document to an interactive document. In/Out are interactive programming features that indicate the last state of the document when it was saved. In a reading mode, the programmatic nature of the prompts of the doesn't matter as much. The ordering is important in verifying that a notebook does not have hidden states from out of order computation. For readers the containing brackets or braces matter less. This may indicate that prompts brackets/braces could be redundant indicator for active/inactive notebooks.