### PR TITLE
improve visual consistency between the various templates

### DIFF
--- a/nbconvert_a11y/exporter.py
+++ b/nbconvert_a11y/exporter.py
@@ -131,8 +131,9 @@ class A11yExporter(PostProcess, HTMLExporter):
         )
         return c
 
-    def from_notebook_node(self, nb, resources=None, **kw):
-        # this is trash and needs serious fixing
+    def init_resources(self, resources=None):
+        if resources is None:
+            resources = {}
         resources = resources or {}
         resources["include_axe"] = self.include_axe
         resources["include_settings"] = self.include_settings
@@ -149,8 +150,12 @@ class A11yExporter(PostProcess, HTMLExporter):
         resources["prompt_out"] = self.prompt_out
         resources["prompt_left"] = self.prompt_left
         resources["prompt_right"] = self.prompt_right
+        return resources
 
-        return super().from_notebook_node(nb, resources, **kw)
+    def from_notebook_node(self, nb, resources=None, **kw):
+        # this is trash and needs serious fixing
+
+        return super().from_notebook_node(nb, self.init_resources(resources), **kw)
 
     def post_process_html(self, body):
         """A final pass at the exported html to add table of contents, heading links, and other a11y affordances."""
@@ -239,6 +244,7 @@ def mdtoc(html):
         id = header.attrs.get("id")
         if not id:
             from slugify import slugify
+
             if header.string:
                 id = slugify(header.string)
             else:
@@ -263,6 +269,7 @@ def heading_links(html):
         id = header.attrs.get("id")
         if not id:
             from slugify import slugify
+
             if header.string:
                 id = slugify(header.string)
             else:

--- a/nbconvert_a11y/exporter.py
+++ b/nbconvert_a11y/exporter.py
@@ -72,8 +72,11 @@ class A11yExporter(PostProcess, HTMLExporter):
     include_settings = Bool(False, help="include configurable accessibility settings dialog.").tag(
         config=True
     )
+    # if help is not included the a bunch of aria label get fucked up and we fail
+    # accessibility. if help information isn't included then we'll at least to included
+    # a vocabulary to reference from the aria-labelledby aria-describedby
     include_help = Bool(
-        False, help="include help and supplementary descriptions about notebooks and cells"
+        True, help="include help and supplementary descriptions about notebooks and cells"
     ).tag(config=True)
     include_toc = Bool(
         True, help="collect a table of contents of the headings in the document"

--- a/nbconvert_a11y/exporter.py
+++ b/nbconvert_a11y/exporter.py
@@ -243,7 +243,7 @@ def mdtoc(html):
     import io
 
     toc = io.StringIO()
-    for header in html.select("#cells :is(h1,h2,h3,h4,h5,h6)"):
+    for header in html.select(".cell :is(h1,h2,h3,h4,h5,h6)"):
         id = header.attrs.get("id")
         if not id:
             from slugify import slugify
@@ -255,7 +255,6 @@ def mdtoc(html):
 
         # there is missing logistics for managely role=heading
         # adding code group semantics will motivate this addition
-
         level = int(header.name[-1])
         toc.write("  " * (level - 1) + f"* [{header.string}](#{id})\n")
     return toc.getvalue()

--- a/nbconvert_a11y/templates/a11y/base.html.j2
+++ b/nbconvert_a11y/templates/a11y/base.html.j2
@@ -25,7 +25,7 @@ the notebook experiennce from browse to edit/focus mode.
 </style>
 {% for theme in ["light", "dark"] %}
 <style type="text/css" id="nb-{{theme}}-theme" media="{% if loop.index - 1%}not  {% endif %}screen">
-    {% include "a11y/static/theme/{}.css".format(resources.code_theme.format(theme)) %}
+    {% include "a11y/static/theme/{}.css" .format(resources.code_theme.format(theme)) %}
 </style>
 {% endfor %}
 {% endblock notebook_css %}
@@ -79,6 +79,7 @@ the notebook experiennce from browse to edit/focus mode.
             accesskey="?">help</button>{% endif %}
     </section>
     <footer>
+        {{footer}}
         {{activity_log()}}
         <a href="#TOP" accesskey="0">skip to top</a>
     </footer>

--- a/nbconvert_a11y/templates/a11y/components/cell.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/cell.html.j2
@@ -2,7 +2,7 @@
 {% from "a11y/components/displays.html.j2" import cell_display_priority with context %}
 
 {% macro cell_anchor(i, cell_type, hidden=False)%}
-<a href="#{{i}}" id="{{i}}" aria-labelledby="nb-cell-label {{i}}" {% if resources.accesskey_navigation and isinstance(i,
+<a class="nb-anchor" href="#{{i}}" id="{{i}}" aria-labelledby="nb-cell-label {{i}}" {% if resources.accesskey_navigation and isinstance(i,
     int) and (i < 10) %}accesskey="{{i}}" {% endif %}
     aria-describedby="nb-{{cell_type}}-label nb-cell-label cell-{{i}}-loc nb-loc-label" {{hide(hidden)}}>{{i}}</a>
 {% endmacro %}
@@ -20,7 +20,7 @@ that would include talking to the kernel. #}
 
 {% macro cell_cell_type(i, cell_type, hidden=False) %}
 {% set selected = ' selected id="cell-{}-cell_type"'.format(i) %}
-<label id="nb-cell-{{i}}-select" {{hide(hidden)}}>cell type
+<label class="nb-cell_type" id="nb-cell-{{i}}-select" {{hide(hidden)}}>cell type
     <select name="cell_type" form="cell-{{i}}">
         <option value="markdown" {%- if cell_type=="markdown" %}{{selected}}{% endif%}>markdown</option>
         <option value="code" {%- if cell_type=="code" %}{{selected}}{% endif%}>code</option>
@@ -30,7 +30,7 @@ that would include talking to the kernel. #}
 {% endmacro %}
 
 {% macro cell_execution_count(i, execution_count, hidden=False) %}
-<label id="cell-{{i}}-source-label">
+<label id="cell-{{i}}-source-label" class="nb-execution_count" {{hide(hidden)}}>
     <span>{{resources.prompt_in}}</span>
     <span aria-hidden="true">{{resources.prompt_left}}</span>
     <span>{{execution_count}}</span>
@@ -40,7 +40,7 @@ that would include talking to the kernel. #}
 
 
 {% macro cell_source(i, source, cell_type, execution_count, hidden=False) %}
-<textarea form="cell-{{i}}" id="cell-{{i}}-source" name="source" rows="{{source.splitlines().__len__()}}"
+<textarea class="nb-source" form="cell-{{i}}" id="cell-{{i}}-source" name="source" rows="{{source.splitlines().__len__()}}"
     aria-labelledby="cell-{{i}}-source-label nb-source-label" readonly>{{source}}</textarea>
 <div role="group" aria-labelledby="nb-source-label">
     {{highlight(source, cell_type)}}
@@ -48,7 +48,7 @@ that would include talking to the kernel. #}
 {% endmacro %}
 
 {% macro cell_metadata(i, metadata, hidden=False) %}
-<button name="metadata" form="cell-{{i}}" aria-describedby="nb-metadata-desc" aria-controls="cell-{{i}}-metadata"
+<button class="nb-metadata" name="metadata" form="cell-{{i}}" aria-describedby="nb-metadata-desc" aria-controls="cell-{{i}}-metadata"
     onclick="openDialog()" {{hide(hidden)}}>metadata</button>
 <dialog id="cell-{{i}}-metadata">
     <form>
@@ -63,12 +63,12 @@ that would include talking to the kernel. #}
 {%- macro cell_output(i, cell, source, outputs, cell_type, execution_count, hidden=False) -%}
 {% set CODE = cell_type == "code" %}
 {% if CODE %}
-{% if not outputs %}
-<span class="visually-hidden" id="cell-{{i}}-outputs-len">In {{execution_count}} has {{outputs.__len__()}}
+{% if execution_count and not outputs %}
+<span class="nb-outputs" class="visually-hidden" id="cell-{{i}}-outputs-len">In {{execution_count}} has {{outputs.__len__()}}
     outputs.</span>
 {% else %}
 {# the following span should get its own column in the table #}
-<fieldset {{hide(hidden)}} data-outputs="{{outputs.__len__()}}">
+<fieldset class="nb-outputs" {{hide(hidden)}} data-outputs="{{outputs.__len__()}}">
     <legend id="cell-{{i}}-outputs-label" aria-describedby="nb-outputs-desc">
         <span>{{resources.prompt_out}}</span>
         <span aria-hidden="true">{{resources.prompt_left}}</span>
@@ -96,7 +96,7 @@ that would include talking to the kernel. #}
     data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
     {{cell_anchor(loop.index, cell.cell_type)}}
     {{cell_form(i, hidden=True)}}
-    {{cell_execution_count(loopindex, cell.execution_count, hidden=True)}}
+    {{cell_execution_count(loopindex, cell.execution_count, hidden=(cell.cell_type=="markdown" or cell.execution_count==None))}}
     {{cell_cell_type(loop.index, cell.cell_type, hidden=True)}}
     {{cell_source(loop.index, cell.source, cell.cell_type, cell.execution_count, hidden=cell.cell_type != "code")}}
     {{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type, cell.execution_count)}}

--- a/nbconvert_a11y/templates/a11y/components/cell.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/cell.html.j2
@@ -65,7 +65,7 @@ that would include talking to the kernel. #}
 {% set CODE = cell_type == "code" %}
 {% if CODE %}
 {% if execution_count and not outputs %}
-<span class="nb-outputs" class="visually-hidden" id="cell-{{i}}-outputs-len">In {{execution_count}} has
+<span class="nb-outputs visually-hidden" id="cell-{{i}}-outputs-len">In {{execution_count}} has
     {{outputs.__len__()}}
     outputs.</span>
 {% else %}

--- a/nbconvert_a11y/templates/a11y/components/cell.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/cell.html.j2
@@ -2,8 +2,8 @@
 {% from "a11y/components/displays.html.j2" import cell_display_priority with context %}
 
 {% macro cell_anchor(i, cell_type, hidden=False)%}
-<a class="nb-anchor" href="#{{i}}" id="{{i}}" aria-labelledby="nb-cell-label {{i}}" {% if resources.accesskey_navigation and isinstance(i,
-    int) and (i < 10) %}accesskey="{{i}}" {% endif %}
+<a class="nb-anchor" href="#{{i}}" id="{{i}}" aria-labelledby="nb-cell-label {{i}}" {% if resources.accesskey_navigation
+    and isinstance(i, int) and (i < 10) %}accesskey="{{i}}" {% endif %}
     aria-describedby="nb-{{cell_type}}-label nb-cell-label cell-{{i}}-loc nb-loc-label" {{hide(hidden)}}>{{i}}</a>
 {% endmacro %}
 
@@ -40,16 +40,17 @@ that would include talking to the kernel. #}
 
 
 {% macro cell_source(i, source, cell_type, execution_count, hidden=False) %}
-<textarea class="nb-source" form="cell-{{i}}" id="cell-{{i}}-source" name="source" rows="{{source.splitlines().__len__()}}"
-    aria-labelledby="cell-{{i}}-source-label nb-source-label" readonly>{{source}}</textarea>
+<textarea class="nb-source" form="cell-{{i}}" id="cell-{{i}}-source" name="source"
+    rows="{{source.splitlines().__len__()}}" aria-labelledby="cell-{{i}}-source-label nb-source-label"
+    readonly>{{source}}</textarea>
 <div role="group" aria-labelledby="nb-source-label">
     {{highlight(source, cell_type)}}
 </div>
 {% endmacro %}
 
 {% macro cell_metadata(i, metadata, hidden=False) %}
-<button class="nb-metadata" name="metadata" form="cell-{{i}}" aria-describedby="nb-metadata-desc" aria-controls="cell-{{i}}-metadata"
-    onclick="openDialog()" {{hide(hidden)}}>metadata</button>
+<button class="nb-metadata" name="metadata" form="cell-{{i}}" aria-describedby="nb-metadata-desc"
+    aria-controls="cell-{{i}}-metadata" onclick="openDialog()" {{hide(hidden)}}>metadata</button>
 <dialog id="cell-{{i}}-metadata">
     <form>
         <button formmethod="dialog">Close</button>
@@ -64,7 +65,8 @@ that would include talking to the kernel. #}
 {% set CODE = cell_type == "code" %}
 {% if CODE %}
 {% if execution_count and not outputs %}
-<span class="nb-outputs" class="visually-hidden" id="cell-{{i}}-outputs-len">In {{execution_count}} has {{outputs.__len__()}}
+<span class="nb-outputs" class="visually-hidden" id="cell-{{i}}-outputs-len">In {{execution_count}} has
+    {{outputs.__len__()}}
     outputs.</span>
 {% else %}
 {# the following span should get its own column in the table #}
@@ -89,16 +91,21 @@ that would include talking to the kernel. #}
 {% endif %}
 {%- endmacro -%}
 
+{% macro cell_loc(i, cell, tag="span") %}
+<{{tag}} role="none" class="nb-loc" id="cell-{{i}}-loc" hidden>{{loc(cell)}}</{{tag}}>
+{% endmacro %}
 
 {% macro cell_section(cell, loop, tag="section") %}
 <{{tag}} class="cell {{cell.cell_type}}" aria-labelledby="cell-{{loop.index}}-cell_type {{loop.index}}"
     data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %}
     data-outputs="{{cell.outputs.__len__()}}" {% endif %}>
     {{cell_anchor(loop.index, cell.cell_type)}}
-    {{cell_form(i, hidden=True)}}
-    {{cell_execution_count(loopindex, cell.execution_count, hidden=(cell.cell_type=="markdown" or cell.execution_count==None))}}
+    {{cell_form(loop.index, hidden=True)}}
+    {% set hide_exec_ct =cell.cell_type=="markdown" or cell.execution_count==None %}
+    {{cell_execution_count(loop.index, cell.execution_count, hidden=hide_exec_ct)}}
     {{cell_cell_type(loop.index, cell.cell_type, hidden=True)}}
     {{cell_source(loop.index, cell.source, cell.cell_type, cell.execution_count, hidden=cell.cell_type != "code")}}
+    {{cell_loc(loop.index, cell)}}
     {{cell_output(loop.index, cell, cell.source, cell.outputs, cell.cell_type, cell.execution_count)}}
     {{cell_metadata(loop.index, cell.metadata, hidden=True)}}
 </{{tag}}>

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -120,8 +120,9 @@ td[role="none"]:not([hidden]) {
     display: unset;
 }
 
-#cells .cell,
-#cells tbody {
+main>.cell,
+#cells>.cell,
+#cells>tbody {
     display: flex;
     flex-direction: column;
 }

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -77,7 +77,6 @@ WCAG 2.1 defines a huge stinking AAA hit size for buttons. its beautiful.
     font-size: max(44px, var(--nb-font-size));
 }
 
-
 /* WCAG 2.2 clarified a AA button size that is used to style checkboxes and buttons. */
 /* satisfy AA 2.5.8 minimum target requirement */
 .wcag-aa button,
@@ -97,9 +96,11 @@ the design decisions are focused native elements so that the assistive technolog
 
 */
 
+.markdown textarea[name=source]+[role=group],
 .wcag-a textarea[name=source],
 .wcag-aa textarea[name=source],
-.wcag-aaa textarea[name=source]~* {
+/* this group selector is very ambiguous */
+.wcag-aaa textarea[name=source]+[role=group] {
     display: none;
 }
 

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -122,7 +122,7 @@ td[role="none"]:not([hidden]) {
 
 main>.cell,
 #cells>.cell,
-#cells>tbody {
+#cells>tbody>.cell {
     display: flex;
     flex-direction: column;
 }

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -99,6 +99,7 @@ the design decisions are focused native elements so that the assistive technolog
 .markdown textarea[name=source]+[role=group],
 .wcag-a textarea[name=source],
 .wcag-aa textarea[name=source],
+.wcag-aaa .markdown textarea[name=source],
 /* this group selector is very ambiguous */
 .wcag-aaa textarea[name=source]+[role=group] {
     display: none;

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -120,12 +120,13 @@ td[role="none"]:not([hidden]) {
     display: unset;
 }
 
-#cells tr.cell,
+#cells .cell,
 #cells tbody {
     display: flex;
     flex-direction: column;
 }
 
+ol[reversed]#cells,
 [reversed]#cells tbody {
     flex-direction: column-reverse;
 }

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -121,9 +121,13 @@ td[role="none"]:not([hidden]) {
     display: unset;
 }
 
+table {
+    border-spacing: unset;
+}
+
 main>.cell,
-#cells>.cell,
-#cells>tbody>.cell {
+#cells .cell,
+#cells > tbody {
     display: flex;
     flex-direction: column;
 }

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -104,6 +104,15 @@ the design decisions are focused native elements so that the assistive technolog
     display: none;
 }
 
+/* this is only needed for the lsit template variant */
+ol#cells {
+    margin: unset;
+    padding: unset;
+}
+
+li.cell {
+    list-style-type: none;
+}
 
 /* ## notebook components layout */
 

--- a/nbconvert_a11y/templates/a11y/table.html.j2
+++ b/nbconvert_a11y/templates/a11y/table.html.j2
@@ -18,8 +18,7 @@ cell_form, cell_source, cell_metadata, cell_output with context%}
     <td role="none" class="nb-toolbar" hidden>{{cell_form(loop.index)}}</td>
     <td role="none" class="nb-start" id="cell-{{loop.index}}-start" hidden>
         {% set t0 = cell.get("metadata", {}).get("execution", {}).get("iopub.execute_input", "") %}
-        {{time(t0)}}
-    </td>
+        {{time(t0)}}</td>
     <td role="none" class="nb-end" id="cell-{{loop.index}}-end" hidden>
         {% set t1 = cell.get("metadata", {}).get("execution", {}).get("shell.execute_reply", "") %}
         {{time(t1)}}
@@ -94,6 +93,8 @@ cell_form, cell_source, cell_metadata, cell_output with context%}
 </table>
 {% endblock body_loop %}
 
+{# adding a template element is a forward thinking move because 
+the template provides the structure for new cells when they are added. #}
 {% block template_element %}
 <template>
     <table>

--- a/tests/configurations/section.py
+++ b/tests/configurations/section.py
@@ -2,4 +2,5 @@
 
 c.NbConvertApp.export_format = "a11y-landmark"
 c.A11yExporter.include_settings = True
+c.A11yExporter.include_help = True
 c.A11yExporter.wcag_priority = "AA"

--- a/tests/test_a11y_baseline.py
+++ b/tests/test_a11y_baseline.py
@@ -15,6 +15,7 @@ from nbconvert_a11y.pytest_axe import JUPYTER_WIDGETS, MATHJAX, SA11Y
     [
         ("a11y.py", "a11y-table", "lorenz-executed.ipynb"),
         ("section.py", "a11y-landmark", "lorenz-executed.ipynb"),
+        ("list.py", "a11y-list", "lorenz-executed.ipynb"),
     ],
 )
 def test_axe(axe, notebook, config, exporter_name, name):

--- a/tests/test_w3c.py
+++ b/tests/test_w3c.py
@@ -34,6 +34,13 @@ htmls = pytest.mark.parametrize(
         ),
         pytest.param(
             get_target_html(
+                (CONFIGURATIONS / (a := "section")).with_suffix(".py"),
+                (NOTEBOOKS / (b := "lorenz-executed")).with_suffix(".ipynb"),
+            ),
+            id="-".join((b, a)),
+        ),
+        pytest.param(
+            get_target_html(
                 (CONFIGURATIONS / (a := "default")).with_suffix(".py"),
                 (NOTEBOOKS / (b := "lorenz-executed")).with_suffix(".ipynb"),
             ),

--- a/tests/test_w3c.py
+++ b/tests/test_w3c.py
@@ -41,6 +41,13 @@ htmls = pytest.mark.parametrize(
         ),
         pytest.param(
             get_target_html(
+                (CONFIGURATIONS / (a := "list")).with_suffix(".py"),
+                (NOTEBOOKS / (b := "lorenz-executed")).with_suffix(".ipynb"),
+            ),
+            id="-".join((b, a)),
+        ),
+        pytest.param(
+            get_target_html(
                 (CONFIGURATIONS / (a := "default")).with_suffix(".py"),
                 (NOTEBOOKS / (b := "lorenz-executed")).with_suffix(".ipynb"),
             ),


### PR DESCRIPTION
`nbconvert-a11y` ships multiple nbconvert notebook templates for the sake of testing and completeness.

most development has occured on the flexible table interface that provides multiple screen reader navigation modes. each of the `table` navigation modes have independent landmark, list, or presentation layouts that are provided by the library. multi assistive layouts allows designers and testers to explore experiences in either complex or isolated ways.

- [ ] axe tests for the sections and list templates.