### PR TITLE
make the assistive technology representation of the table configurable 

### DIFF
--- a/nbconvert_a11y/exporter.py
+++ b/nbconvert_a11y/exporter.py
@@ -126,6 +126,7 @@ class A11yExporter(PostProcess, HTMLExporter):
     ).tag(config=True)
     include_visibility = Bool(False, help="include visibility toggle").tag(config=True)
     include_upload = Bool(False, help="include template for uploading new content").tag(config=True)
+    allow_run_mode = Bool(False, help="enable buttons for a run mode").tag(config=True)
     hide_anchor_links = Bool(False).tag(config=True)
     exclude_anchor_links = Bool(True).tag(config=True)
     code_theme = Enum(list(THEMES), "gh-high", help="an accessible pygments dark/light theme").tag(
@@ -200,6 +201,7 @@ class A11yExporter(PostProcess, HTMLExporter):
         resources["exclude_anchor_links"] = self.exclude_anchor_links
         resources["hide_anchor_links"] = self.hide_anchor_links
         resources["table_pattern"] = getattr(Roles, self.table_pattern)
+        resources["allow_run_mode"] = self.allow_run_mode
         return resources
 
     def from_notebook_node(self, nb, resources=None, **kw):

--- a/nbconvert_a11y/templates/a11y/base.html.j2
+++ b/nbconvert_a11y/templates/a11y/base.html.j2
@@ -35,37 +35,30 @@ the notebook experiennce from browse to edit/focus mode.
 {% block body_header %}
 
 <body class="wcag-{{resources.wcag_priority.lower()}}">
-    <header aria-label="site header">
+    <header>
         <a href="#1" id="TOP">skip to main content</a>
         {{site_navigation | default("")}}
-    </header>
-    <main aria-labelledby="nb-notebook-label">
         {%- if resources.include_summary -%}{% include "a11y/components/nb-summary.html.j2"%}{%- endif -%}
         {%- if resources.include_toc -%}{% include "a11y/components/toc.html.j2" %}{%- endif -%}
-        {% endblock body_header %}
-
-        {% block body_footer scoped %}
-        {# dialogs need to be outside the form because we cant nest forms #}
         <dialog id="nb-metadata">
             <form method="dialog">
                 <button formmethod="dialog">Close</button>
                 {{nb.metadata| json_dumps | escape_html_keep_quotes }}
             </form>
         </dialog>
-        {% include "a11y/components/nb-toolbar.html.j2" %}
+    </header>
+    <main>
+        {% endblock body_header %}
+
+        {% block body_footer scoped %}
+        {# dialogs need to be outside the form because we cant nest forms #}
     </main>
     {# a notebook begins as a static document that can progressively
     add features like run time computation. #}
     {# skip to top is needed for long notebooks.
     it is difficult to access for keyboard users. #}
-    <section id="nb-dialogs">
-        <details>
-            <summary onclick="openDialogs()">settings, help, & diagnostics</summary>
-        </details>
-        {% if resources.include_settings %}{% include "a11y/components/settings.html.j2" %}{% endif %}
-        {% if resources.include_visibility %}{% include "a11y/components/visibility.html.j2"%}{% endif %}
-        {% if resources.include_help %}{% include "a11y/components/help.html.j2" %}{% endif %}
-        {% if resources.include_axe %}{% include "a11y/components/audit.html.j2" %}{% endif %}
+    <footer>
+        {% include "a11y/components/nb-toolbar.html.j2" %}
         {# make the individual settings discoverable before all the settings
         when using shift+tab #}
         {% if resources.include_settings %}
@@ -78,8 +71,10 @@ the notebook experiennce from browse to edit/focus mode.
             onclick="openDialog()">audit</button>{% endif %}
         {% if resources.include_help %}<button onclick="openDialog()" aria-controls="nb-help"
             accesskey="?">help</button>{% endif %}
-    </section>
-    <footer>
+        {% if resources.include_settings %}{% include "a11y/components/settings.html.j2" %}{% endif %}
+        {% if resources.include_visibility %}{% include "a11y/components/visibility.html.j2"%}{% endif %}
+        {% if resources.include_help %}{% include "a11y/components/help.html.j2" %}{% endif %}
+        {% if resources.include_axe %}{% include "a11y/components/audit.html.j2" %}{% endif %}
         {{footer}}
         {{activity_log()}}
         <a href="#TOP" accesskey="0">skip to top</a>

--- a/nbconvert_a11y/templates/a11y/base.html.j2
+++ b/nbconvert_a11y/templates/a11y/base.html.j2
@@ -40,6 +40,7 @@ the notebook experiennce from browse to edit/focus mode.
         {{site_navigation | default("")}}
     </header>
     <main aria-labelledby="nb-notebook-label">
+        {%- if resources.include_summary -%}{% include "a11y/components/nb-summary.html.j2"%}{%- endif -%}
         {%- if resources.include_toc -%}{% include "a11y/components/toc.html.j2" %}{%- endif -%}
         {% endblock body_header %}
 

--- a/nbconvert_a11y/templates/a11y/components/help.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/help.html.j2
@@ -145,7 +145,7 @@ what about internationalization? how does scheme effect internalization? #}
                     </dd>
                     <dt id="nb-attachments-label">attachments</dt>
                     <dd id="nb-attachments-desc">{{schema.definitions.misc.attachments.description}}</dd>
-                    <dt id="nb-loc-label">lines of code</dt>
+                    <dt>lines of code</dt>
                     <dd>lines of code in the cell, including whitespace.</dd>
                     {# this probably should be significant lines of code #}
                 </dl>

--- a/nbconvert_a11y/templates/a11y/components/nb-summary.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/nb-summary.html.j2
@@ -1,6 +1,6 @@
 {%- set title = nb.metadata.get("title") -%}
 {%- set description = nb.metadata.get("description") -%}
-{% set describedby = "nb-ct-total nb-cells-label nb-ct-code nb-code-label nb-state nb-ct-loc nb-loc-label
+{% set describedby = "nb-ct-total nb-cells-label nb-ct-code nb-state nb-ct-loc nb-loc-label
 nb-ct-outputs nb-outputs-label"%}
 <details>
     <summary id="nb-summary-label" aria-describedby="{{describedby}}">notebook summary</summary>
@@ -19,7 +19,7 @@ nb-ct-outputs nb-outputs-label"%}
         {%- endif -%}
         <dt>cells</dt>
         <dd id="nb-ct-total">{{len(nb.cells)}} total</dd>
-        <dd id="nb-ct-code">{{nb | count_code_cells}} <span id="nb-code-label">code</span></dd>
+        <dd id="nb-ct-code">{{nb | count_code_cells}} code</dd>
         <dd></dd>
         <dt>state</dt>
         <dd id="nb-state">{{nb | is_ordered}}</dd>

--- a/nbconvert_a11y/templates/a11y/components/nb-summary.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/nb-summary.html.j2
@@ -2,36 +2,39 @@
 {%- set description = nb.metadata.get("description") -%}
 {% set describedby = "nb-ct-total nb-cells-label nb-ct-code nb-state nb-ct-loc nb-loc-label
 nb-ct-outputs nb-outputs-label"%}
-<details>
-    <summary id="nb-summary-label" aria-describedby="{{describedby}}">notebook summary</summary>
-    <dl aria-labelledby="nb-summary-label">
-        {%- if nb.metadata.get("title") -%}
-        <dt>title</dt>
-        <dd id="nb-title">{{nb.metadata.title}}</dd>
-        {%- endif -%}
-        {%- if nb.metadata.get("description") -%}
-        <dt>description</dt>
-        <dd id="">{{nb.metadata.description}}</dd>
-        {%- endif -%}
-        {%- if nb.metadata.get("authors") -%}
-        <dt>authors</dt>
-        {%- for author in nb.metadata.authors -%}<dd>{{author}}</dd>{%- endfor -%}
-        {%- endif -%}
-        <dt>cells</dt>
-        <dd id="nb-ct-total">{{len(nb.cells)}} total</dd>
-        <dd id="nb-ct-code">{{nb | count_code_cells}} code</dd>
-        <dd></dd>
-        <dt>state</dt>
-        <dd id="nb-state">{{nb | is_ordered}}</dd>
-        {% set lang = nb.metadata.get("language_info", {}).get("name") or nb.metadata.get("kernelspec",
-        {}).get("name")%}
-        {% if lang %}
-        <dt>language</dt>
-        <dd id="nb-lang">{{lang}}</dd>
-        {% endif %}
-        <dt id="nb-loc-label">lines of code</dt>
-        <dd id="nb-ct-loc">{{nb | count_loc}}</dd>
-        <dt>outputs</dt>
-        <dd id="nb-ct-outputs">{{nb | count_outputs }}</dd>
-    </dl>
-</details>
+<section aria-labelledby="nb-summary-label">
+    <details>
+        <summary id="nb-summary-label" aria-describedby="{{describedby}}">notebook summary</summary>
+        <button aria-controls="nb-metadata" onclick="openDialog()">show metadata</button>
+        <dl aria-labelledby="nb-summary-label">
+            {%- if nb.metadata.get("title") -%}
+            <dt>title</dt>
+            <dd id="nb-title">{{nb.metadata.title}}</dd>
+            {%- endif -%}
+            {%- if nb.metadata.get("description") -%}
+            <dt>description</dt>
+            <dd id="">{{nb.metadata.description}}</dd>
+            {%- endif -%}
+            {%- if nb.metadata.get("authors") -%}
+            <dt>authors</dt>
+            {%- for author in nb.metadata.authors -%}<dd>{{author}}</dd>{%- endfor -%}
+            {%- endif -%}
+            <dt>cells</dt>
+            <dd id="nb-ct-total">{{len(nb.cells)}} total</dd>
+            <dd id="nb-ct-code">{{nb | count_code_cells}} code</dd>
+            <dd></dd>
+            <dt>state</dt>
+            <dd id="nb-state">{{nb | is_ordered}}</dd>
+            {% set lang = nb.metadata.get("language_info", {}).get("name") or nb.metadata.get("kernelspec",
+            {}).get("name")%}
+            {% if lang %}
+            <dt>language</dt>
+            <dd id="nb-lang">{{lang}}</dd>
+            {% endif %}
+            <dt id="nb-loc-label">lines of code</dt>
+            <dd id="nb-ct-loc">{{nb | count_loc}}</dd>
+            <dt>outputs</dt>
+            <dd id="nb-ct-outputs">{{nb | count_outputs }}</dd>
+        </dl>
+    </details>
+</section>

--- a/nbconvert_a11y/templates/a11y/components/nb-summary.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/nb-summary.html.j2
@@ -1,0 +1,37 @@
+{%- set title = nb.metadata.get("title") -%}
+{%- set description = nb.metadata.get("description") -%}
+{% set describedby = "nb-ct-total nb-cells-label nb-ct-code nb-code-label nb-state nb-ct-loc nb-loc-label
+nb-ct-outputs nb-outputs-label"%}
+<details>
+    <summary id="nb-summary-label" aria-describedby="{{describedby}}">notebook summary</summary>
+    <dl aria-labelledby="nb-summary-label">
+        {%- if nb.metadata.get("title") -%}
+        <dt>title</dt>
+        <dd id="nb-title">{{nb.metadata.title}}</dd>
+        {%- endif -%}
+        {%- if nb.metadata.get("description") -%}
+        <dt>description</dt>
+        <dd id="">{{nb.metadata.description}}</dd>
+        {%- endif -%}
+        {%- if nb.metadata.get("authors") -%}
+        <dt>authors</dt>
+        {%- for author in nb.metadata.authors -%}<dd>{{author}}</dd>{%- endfor -%}
+        {%- endif -%}
+        <dt>cells</dt>
+        <dd id="nb-ct-total">{{len(nb.cells)}} total</dd>
+        <dd id="nb-ct-code">{{nb | count_code_cells}} <span id="nb-code-label">code</span></dd>
+        <dd></dd>
+        <dt>state</dt>
+        <dd id="nb-state">{{nb | is_ordered}}</dd>
+        {% set lang = nb.metadata.get("language_info", {}).get("name") or nb.metadata.get("kernelspec",
+        {}).get("name")%}
+        {% if lang %}
+        <dt>language</dt>
+        <dd id="nb-lang">{{lang}}</dd>
+        {% endif %}
+        <dt id="nb-loc-label">lines of code</dt>
+        <dd id="nb-ct-loc">{{nb | count_loc}}</dd>
+        <dt>outputs</dt>
+        <dd id="nb-ct-outputs">{{nb | count_outputs }}</dd>
+    </dl>
+</details>

--- a/nbconvert_a11y/templates/a11y/components/nb-toolbar.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/nb-toolbar.html.j2
@@ -1,5 +1,5 @@
-<form name="notebook" id="notebook" aria-labelledby="nb-notebook-label">
+{% from "a11y/components/core.html.j2" import hide %}
+<form name="notebook" id="notebook" aria-labelledby="nb-notebook-label" {{hide(not resources.allow_run_mode)}}>
     <label><input id="nb-edit-mode" type="checkbox" name="edit">edit mode</label>
-    <button aria-controls="nb-metadata" onclick="openDialog()">metadata</button>
     <button type="submit">Run</button>
 </form>

--- a/nbconvert_a11y/templates/a11y/components/settings.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/settings.html.j2
@@ -16,7 +16,8 @@ settings provides multiple screen reader navigation techniques when the dialog i
                     <li>{{select("color scheme", {"light mode": "light", "dark mode": "dark"})}}</li>
                     <li>{{input_number("margin", 5, min=0, max=40, step=5, extra_title="%")}}</li>
                     <li>{{input_number("line height", 1.5, min=0.5, max=3, step=0.1)}}</li>
-                    <li>{{select("cell navigation", values="list table landmark presentation".split(), disabled="grid
+                    <li>{{select("cell navigation", default=resources.table_pattern.__name__.lower(), values="list table
+                        region presentation".split(), disabled="grid
                         treegrid
                         tree".split())}}</li>
                     {% set priority = {"Triple A": "AAA","Double A": "AA", "Single A": "A"}%}

--- a/nbconvert_a11y/templates/a11y/components/visibility.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/visibility.html.j2
@@ -28,32 +28,36 @@
     <form name="visibility">
         <button formmethod="dialog">Close</button>
         {{checkbox("visually hide", False)}}
-
-        <table aria-label="notebook cell visibility" role="grid">
-            <tbody>
-                {# the table head is used to provide controls #}
-                {# it hints at a configurable pattern for showing different features. #}
-                {# there should be controls for each cell type here, and cell types can be
-                added. #}
-                {% set labels = "index execution_count !cell_type source outputs !metadata !toolbar !loc" %}
-                {{header_row(labels)}}
-                {{checkbox_row("code", labels)}}
-                {{checkbox_row("markdown", labels)}}
-                {{checkbox_row("raw", labels)}}
-            </tbody>
-        </table>
+        <fieldset disabled>
+            <legend>visibility</legend>
+            <table aria-label="notebook cell visibility" role="grid">
+                <tbody>
+                    {# the table head is used to provide controls #}
+                    {# it hints at a configurable pattern for showing different features. #}
+                    {# there should be controls for each cell type here, and cell types can be
+                    added. #}
+                    {% set labels = "index execution_count !cell_type source outputs !metadata !toolbar !loc" %}
+                    {{header_row(labels)}}
+                    {{checkbox_row("code", labels)}}
+                    {{checkbox_row("markdown", labels)}}
+                    {{checkbox_row("raw", labels)}}
+                </tbody>
+            </table>
+        </fieldset>
     </form>
     <form name="expanded">
-        <button formmethod="dialog">Close</button>
-        <table role="grid">
-            <tbody>
-                {% set labels = "cell source outputs" %}
-                {{header_row(labels)}}
-                {{checkbox_row("code", labels)}}
-                {{checkbox_row("markdown", labels)}}
-                {{checkbox_row("raw", labels)}}
-            </tbody>
-        </table>
+        <fieldset disabled>
+            <legend>expand/collapse</legend>
+            <table role="grid">
+                <tbody>
+                    {% set labels = "cell source outputs" %}
+                    {{header_row(labels)}}
+                    {{checkbox_row("code", labels)}}
+                    {{checkbox_row("markdown", labels)}}
+                    {{checkbox_row("raw", labels)}}
+                </tbody>
+            </table>
+        </fieldset>
     </form>
     {{activity_log()}}
 

--- a/nbconvert_a11y/templates/a11y/static/settings.js
+++ b/nbconvert_a11y/templates/a11y/static/settings.js
@@ -2,7 +2,7 @@ const BODY = document.querySelector("body"), SELECTORS = {
     "table": "table#cells",
     "body": "table#cells>tbody",
     "row": "table#cells>tbody>tr",
-    "heading": "table#cells>tbody>tr>th",
+    "header": "table#cells>tbody>tr>th",
     "cell": "table#cells>tbody>tr>td",
 }, ROLES = {
     "list": {

--- a/nbconvert_a11y/templates/a11y/static/settings.js
+++ b/nbconvert_a11y/templates/a11y/static/settings.js
@@ -17,7 +17,7 @@ const BODY = document.querySelector("body"), SELECTORS = {
         "row": "row",
         "header": "rowheader",
         "cell": "cell",
-    }, "landmark": {
+    }, "region": {
         "table": "presentation",
         "body": "presentation",
         "row": "region",

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -47,10 +47,6 @@ dialog form>* {
     display: block;
 }
 
-#nb-dialogs details[open]~dialog {
-    position: relative;
-}
-
 
 /* ## wcag accessibility guidelines as a feature
 

--- a/nbconvert_a11y/templates/a11y/static/style.css
+++ b/nbconvert_a11y/templates/a11y/static/style.css
@@ -118,8 +118,10 @@ li.cell {
 
 /* ## notebook components layout */
 
-td[role="none"]:not([hidden]) {
+td[role="none"]:not([hidden]),
+th[role="none"]:not([hidden]) {
     display: unset;
+    text-align: unset;
 }
 
 table {

--- a/nbconvert_a11y/templates/a11y/table.html.j2
+++ b/nbconvert_a11y/templates/a11y/table.html.j2
@@ -25,15 +25,18 @@ or cell.metadata.get("transient",{}).get("remove_source", false) -%}
 or not cell.metadata.get("jupyter", {}).get("outputs_hidden", False)-%}
 {%- endif -%}
 {%- set slide_type = cell.get("metadata", {}).get("slide_type") -%}
-<tr role="{{resources.table_pattern.row}}" class="cell {{cell.cell_type}}" aria-labelledby="nb-cell-label {{index}} cell-{{index}}-cell_type"
-    data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %} {% endif %} data-index="{{index}}"
-    {% if slide_type %} data-slide_type="{{slide_type}}" {% endif %}>
-    <th role="{{resources.table_pattern.rowheader}}" class="nb-anchor" scope="row">{{cell_anchor(index, cell.cell_type, cell.execution_count, cell.outputs)}}</td>
-    <td role="{{resources.table_pattern.cell}}" class="nb-execution_count" {{hide(cell.cell_type=="markdown" or cell.execution_count==None or not
-        resources.global_content_filter.include_input_prompt)}}>
+<tr role="{{resources.table_pattern.row}}" class="cell {{cell.cell_type}}"
+    aria-labelledby="nb-cell-label {{index}} cell-{{index}}-cell_type" data-loc="{{cell.source.splitlines().__len__()}}"
+    {% if cell.cell_type=="code" %} {% endif %} data-index="{{index}}" {% if slide_type %}
+    data-slide_type="{{slide_type}}" {% endif %}>
+    <th role="{{resources.table_pattern.rowheader}}" class="nb-anchor" scope="row">{{cell_anchor(index, cell.cell_type,
+        cell.execution_count, cell.outputs)}}</td>
+    <td role="{{resources.table_pattern.cell}}" class="nb-execution_count" {{hide(cell.cell_type=="markdown" or
+        cell.execution_count==None or not resources.global_content_filter.include_input_prompt)}}>
         {{cell_execution_count(index, cell.execution_count)}}
     </td>
-    <td role="{{resources.table_pattern.cell}}" class="nb-cell_type" hidden>{{cell_cell_type(index, cell.cell_type)}}</td>
+    <td role="{{resources.table_pattern.cell}}" class="nb-cell_type" hidden>{{cell_cell_type(index, cell.cell_type)}}
+    </td>
     <td role="{{resources.table_pattern.cell}}" class="nb-toolbar" hidden>{{cell_form(index)}}</td>
     <td role="{{resources.table_pattern.cell}}" class="nb-start" id="cell-{{index}}-start" hidden>
         {% set t0 = cell.get("metadata", {}).get("execution", {}).get("iopub.execute_input", "") %}
@@ -42,13 +45,16 @@ or not cell.metadata.get("jupyter", {}).get("outputs_hidden", False)-%}
         {% set t1 = cell.get("metadata", {}).get("execution", {}).get("shell.execute_reply", "") %}
         {{time(t1)}}
     </td>
-    <td role="{{resources.table_pattern.cell}}" class="nb-source" {{hide(cell.cell_type=="markdown" or not include_input)}}>{{cell_source(index,
+    <td role="{{resources.table_pattern.cell}}" class="nb-source" {{hide(cell.cell_type=="markdown" or not
+        include_input)}}>{{cell_source(index,
         cell.source, cell.cell_type, cell.execution_count)}}</td>
-    <td role="{{resources.table_pattern.cell}}" class="nb-metadata" hidden>{{cell_metadata(index, cell.get("metadata", {}))}}</td>
+    <td role="{{resources.table_pattern.cell}}" class="nb-metadata" hidden>{{cell_metadata(index, cell.get("metadata",
+        {}))}}</td>
     {# it was noted in a video that lines of code were helpful in assistive descriptions.
     lines of code are part of the gestalt of code forms. #}
     <td role="{{resources.table_pattern.cell}}" class="nb-loc" id="cell-{{index}}-loc" hidden>{{loc(cell)}}</td>
-    <td role="{{resources.table_pattern.cell}}" class="nb-outputs" {{hide(not include_outputs)}}>{{cell_output(index, cell, cell.source,
+    <td role="{{resources.table_pattern.cell}}" class="nb-outputs" {{hide(not include_outputs)}}>{{cell_output(index,
+        cell, cell.source,
         cell.outputs,
         cell.cell_type,
         cell.execution_count)}}</td>
@@ -74,46 +80,6 @@ or not cell.metadata.get("jupyter", {}).get("outputs_hidden", False)-%}
         {{cell_row(cell, loop.index)}}
         {% endblock any_cell %}
         {%- endfor -%}
-    </tbody>
-</table>
-
-
-<table class="nb-cells-footer" hidden>
-    <tbody>
-        {# needs a header row #}
-        <tr class="total">
-            <th scope="row">all cells</th>
-            <th scope="row">count</th>
-            <td class="nb-ordered">{{ordered(nb)}}</td>
-            <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
-            <td class="nb-source"></td>
-            <td class="nb-outputs">{{count_outputs(nb)}}</td>
-            <td class="nb-toolbar"></td>
-            <td class="nb-metadata">{# list keys #}</td>
-            <td class="nb-loc">{{count_loc(nb)}}</td>
-        </tr>
-        <tr class="code">
-            <th scope="row">code cells</th>
-            <th scope="row">count</th>
-            <td class="nb-ordered">{{ordered(nb)}}</td>
-            <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
-            <td class="nb-source"></td>
-            <td class="nb-outputs">{{count_outputs(nb)}}</td>
-            <td class="nb-toolbar"></td>
-            <td class="nb-metadata">{# list keys #}</td>
-            <td class="nb-loc">{{count_loc(nb)}}</td>
-        </tr>
-        <tr class="markdown">
-            <th scope="row">markdown cells</th>
-            <th scope="row">count</th>
-            <td class="nb-ordered"></td>
-            <td class="nb-cell_type">{{nb.cells.__len__()}}</td>
-            <td class="nb-source"></td>
-            <td class="nb-outputs"></td>
-            <td class="nb-toolbar"></td>
-            <td class="nb-metadata">{# list keys #}</td>
-            <td class="nb-loc">{{count_loc(nb)}}</td>
-        </tr>
     </tbody>
 </table>
 {% endblock body_loop %}

--- a/nbconvert_a11y/templates/a11y/table.html.j2
+++ b/nbconvert_a11y/templates/a11y/table.html.j2
@@ -25,30 +25,30 @@ or cell.metadata.get("transient",{}).get("remove_source", false) -%}
 or not cell.metadata.get("jupyter", {}).get("outputs_hidden", False)-%}
 {%- endif -%}
 {%- set slide_type = cell.get("metadata", {}).get("slide_type") -%}
-<tr role="listitem" class="cell {{cell.cell_type}}" aria-labelledby="nb-cell-label {{index}} cell-{{index}}-cell_type"
+<tr role="{{resources.table_pattern.row}}" class="cell {{cell.cell_type}}" aria-labelledby="nb-cell-label {{index}} cell-{{index}}-cell_type"
     data-loc="{{cell.source.splitlines().__len__()}}" {% if cell.cell_type=="code" %} {% endif %} data-index="{{index}}"
     {% if slide_type %} data-slide_type="{{slide_type}}" {% endif %}>
-    <td role="none" class="nb-anchor">{{cell_anchor(index, cell.cell_type, cell.execution_count, cell.outputs)}}</td>
-    <td role="none" class="nb-execution_count" {{hide(cell.cell_type=="markdown" or cell.execution_count==None or not
+    <th role="{{resources.table_pattern.rowheader}}" class="nb-anchor" scope="row">{{cell_anchor(index, cell.cell_type, cell.execution_count, cell.outputs)}}</td>
+    <td role="{{resources.table_pattern.cell}}" class="nb-execution_count" {{hide(cell.cell_type=="markdown" or cell.execution_count==None or not
         resources.global_content_filter.include_input_prompt)}}>
         {{cell_execution_count(index, cell.execution_count)}}
     </td>
-    <td role="none" class="nb-cell_type" hidden>{{cell_cell_type(index, cell.cell_type)}}</td>
-    <td role="none" class="nb-toolbar" hidden>{{cell_form(index)}}</td>
-    <td role="none" class="nb-start" id="cell-{{index}}-start" hidden>
+    <td role="{{resources.table_pattern.cell}}" class="nb-cell_type" hidden>{{cell_cell_type(index, cell.cell_type)}}</td>
+    <td role="{{resources.table_pattern.cell}}" class="nb-toolbar" hidden>{{cell_form(index)}}</td>
+    <td role="{{resources.table_pattern.cell}}" class="nb-start" id="cell-{{index}}-start" hidden>
         {% set t0 = cell.get("metadata", {}).get("execution", {}).get("iopub.execute_input", "") %}
         {{time(t0)}}</td>
-    <td role="none" class="nb-end" id="cell-{{index}}-end" hidden>
+    <td role="{{resources.table_pattern.cell}}" class="nb-end" id="cell-{{index}}-end" hidden>
         {% set t1 = cell.get("metadata", {}).get("execution", {}).get("shell.execute_reply", "") %}
         {{time(t1)}}
     </td>
-    <td role="none" class="nb-source" {{hide(cell.cell_type=="markdown" or not include_input)}}>{{cell_source(index,
+    <td role="{{resources.table_pattern.cell}}" class="nb-source" {{hide(cell.cell_type=="markdown" or not include_input)}}>{{cell_source(index,
         cell.source, cell.cell_type, cell.execution_count)}}</td>
-    <td role="none" class="nb-metadata" hidden>{{cell_metadata(index, cell.get("metadata", {}))}}</td>
+    <td role="{{resources.table_pattern.cell}}" class="nb-metadata" hidden>{{cell_metadata(index, cell.get("metadata", {}))}}</td>
     {# it was noted in a video that lines of code were helpful in assistive descriptions.
     lines of code are part of the gestalt of code forms. #}
-    <td role="none" class="nb-loc" id="cell-{{index}}-loc" hidden>{{loc(cell)}}</td>
-    <td role="none" class="nb-outputs" {{hide(not include_outputs)}}>{{cell_output(index, cell, cell.source,
+    <td role="{{resources.table_pattern.cell}}" class="nb-loc" id="cell-{{index}}-loc" hidden>{{loc(cell)}}</td>
+    <td role="{{resources.table_pattern.cell}}" class="nb-outputs" {{hide(not include_outputs)}}>{{cell_output(index, cell, cell.source,
         cell.outputs,
         cell.cell_type,
         cell.execution_count)}}</td>
@@ -57,16 +57,16 @@ or not cell.metadata.get("jupyter", {}).get("outputs_hidden", False)-%}
 
 {% block body_loop %}
 {# the most consistent implementation would connect the input visibility to a form #}
-<table id="cells" role="presentation">
+<table id="cells" role="{{resources.table_pattern.table}}">
     <colgroup>
         {% for col in COLUMNS %}
         <col class="nb-{{col}}">
         {% endfor %}
     </colgroup>
-    <tbody role="list" aria-labelledby="nb-notebook-label nb-cells-label">
-        <tr hidden>
+    <tbody role="{{resources.table_pattern.rowgroup}}" aria-labelledby="nb-notebook-label nb-cells-label">
+        <tr role="{{resources.table_pattern.row}}" hidden>
             {% for col in COLUMNS %}
-            <th scope="col">{{col}}</th>
+            <th role="{{resources.table_pattern.columnheader}}" scope="col">{{col}}</th>
             {% endfor %}
         </tr>
         {%- for cell in nb.cells -%}

--- a/tests/configurations/a11y.py
+++ b/tests/configurations/a11y.py
@@ -1,8 +1,8 @@
 """an accessible nbconvert template"""
 
 c.NbConvertApp.export_format = "a11y"
-c.A11yExporter.include_axe = True
-c.A11yExporter.include_sa11y = True
+c.A11yExporter.include_axe = False
+c.A11yExporter.include_sa11y = False
 c.A11yExporter.include_settings = True
 c.A11yExporter.include_help = True
 c.A11yExporter.include_visibility = True

--- a/tests/test_a11y_settings.py
+++ b/tests/test_a11y_settings.py
@@ -22,7 +22,7 @@ def lorenz(page, notebook):
     [
         "[aria-controls=nb-settings]",
         "[aria-controls=nb-help]",
-        "[aria-controls=nb-metadata]",
+        # "[aria-controls=nb-metadata]",
         param("[aria-controls=nb-expanded-dialog]", marks=mark.xfail(reason=NEEDS_WORK)),
         param("[aria-controls=nb-visibility-dialog]", marks=mark.xfail(reason=NEEDS_WORK)),
         # param("nada", marks=mark.xfail(reason="no selector")),

--- a/tests/test_a11y_settings.py
+++ b/tests/test_a11y_settings.py
@@ -23,7 +23,6 @@ def lorenz(page, notebook):
         "[aria-controls=nb-settings]",
         "[aria-controls=nb-help]",
         "[aria-controls=nb-metadata]",
-        "[aria-controls=nb-audit]",
         param("[aria-controls=nb-expanded-dialog]", marks=mark.xfail(reason=NEEDS_WORK)),
         param("[aria-controls=nb-visibility-dialog]", marks=mark.xfail(reason=NEEDS_WORK)),
         # param("nada", marks=mark.xfail(reason="no selector")),


### PR DESCRIPTION
the table cells can be configured as table, list, region or presentation modes for assistive technologies. 

a use case is an index that list blog posts. the nature of the cells don't matter.

this pull request happened to rework the notebook details and the notebook summary.