### PR TITLE
add interactive execution to the static documents

### DIFF
--- a/nbconvert_a11y/exporter.py
+++ b/nbconvert_a11y/exporter.py
@@ -131,6 +131,7 @@ class A11yExporter(PostProcess):
     code_theme = Enum(list(THEMES), "gh-high", help="an accessible pygments dark/light theme").tag(
         config=True
     )
+    include_thebe = Bool(False, help="include the thebe user interface for interactivity.").tag(config=True)
     table_pattern = Enum(
         list(Roles.options),
         "List",
@@ -201,6 +202,7 @@ class A11yExporter(PostProcess):
         resources["hide_anchor_links"] = self.hide_anchor_links
         resources["table_pattern"] = getattr(Roles, self.table_pattern)
         resources["allow_run_mode"] = self.allow_run_mode
+        resources["include_thebe"] = self.include_thebe
         return resources
 
     def from_notebook_node(self, nb, resources=None, **kw):

--- a/nbconvert_a11y/templates/a11y/components/cell.html.j2
+++ b/nbconvert_a11y/templates/a11y/components/cell.html.j2
@@ -52,7 +52,7 @@ that would include talking to the kernel. #}
 {% macro cell_source(i, source, cell_type, execution_count, hidden=False) %}
 <textarea class="nb-source" form="cell-{{i}}" id="cell-{{i}}-source" name="source"
     rows="{{source.splitlines().__len__()}}" aria-labelledby="cell-{{i}}-in-label cell-{{i}}-exec-label nb-source-label"
-    readonly>{{source}}</textarea>
+    readonly data-language="python" data-executable="true">{{source}}</textarea>
 {# should say something like highlight source #}
 <div role="group" aria-labelledby="cell-{{i}}-in-label cell-{{i}}-exec-label" aria-roledescription="highlighted">
     {{highlight(source, cell_type)}}
@@ -89,11 +89,13 @@ that would include talking to the kernel. #}
         <span>{{execution_count}}</span>
         <span aria-hidden="true">{{resources.prompt_right}}</span>
     </legend>
+    <div>
     {% if outputs %}
     {# the output description should mention the number of outputs
     saying zero outputs should be an option. a cell without an output is probably a violation. #}
     {{cell_display_priority(i, outputs, cell)}}
     {% endif %}
+    </div>
 </fieldset>
 {%- else %}
 {# when there is markdown we show html output;

--- a/nbconvert_a11y/templates/a11y/table.html.j2
+++ b/nbconvert_a11y/templates/a11y/table.html.j2
@@ -67,9 +67,13 @@ and not cell.metadata.get("jupyter", {}).get("outputs_hidden", False)-%}
 {# the most consistent implementation would connect the input visibility to a form #}
 <details>
     <summary>notebook toolbar</summary>
+    {% if resources.include_thebe -%}
     {{thebe_activate()}} {# this needs to be outside the form otherwise it becomes a submission button #}
-    <form name="notebook">
+    {%- endif %}
+    <form name="notebook">]
+        {% if resources.include_thebe -%}
         {{thebe_status()}}
+        {%- endif %}
         <fieldset>
             <legend>cell ordering</legend>
             <input type="radio" name="sorted" id="sort-asc" value="ascending" /><label for="sort-asc">ascending</label>
@@ -107,5 +111,7 @@ the template provides the structure for new cells when they are added. #}
 
 {% block footer_js %}
 {{super()}}
+{% if resources.include_thebe -%}
 {{thebe_head()}}
+{%- endif %}
 {% endblock footer_js %}

--- a/nbconvert_a11y/templates/a11y/table.html.j2
+++ b/nbconvert_a11y/templates/a11y/table.html.j2
@@ -2,6 +2,7 @@
 {% from "a11y/components/core.html.j2" import hide, time, loc %}
 {% from "a11y/components/cell.html.j2" import cell_anchor, cell_execution_count, cell_cell_type,
 cell_form, cell_source, cell_metadata, cell_output with context%}
+{%- from 'a11y/thebe.html.j2' import thebe_status, thebe_activate, thebe_head with context -%}
 {% set COLUMNS = ["index", "execution_count", "cell_type", "toolbar", "started_at", "completed_at", "source", "loc",
 "metadata", "outputs"] %}
 
@@ -64,19 +65,21 @@ and not cell.metadata.get("jupyter", {}).get("outputs_hidden", False)-%}
 
 {% block body_loop %}
 {# the most consistent implementation would connect the input visibility to a form #}
-<form name="notebook">
-    <fieldset>
-        <legend>cell ordering</legend>
-        <input type="radio" name="sorted" id="sort-asc" value="ascending"/><label for="sort-asc">ascending</label>
-        <input type="radio" name="sorted" id="sort-desc" value="descending" /><label for="sort-desc">descending</label>
-    </fieldset>
-</form>
+<details>
+    <summary>notebook toolbar</summary>
+    {{thebe_activate()}} {# this needs to be outside the form otherwise it becomes a submission button #}
+    <form name="notebook">
+        {{thebe_status()}}
+        <fieldset>
+            <legend>cell ordering</legend>
+            <input type="radio" name="sorted" id="sort-asc" value="ascending" /><label for="sort-asc">ascending</label>
+            <input type="radio" name="sorted" id="sort-desc" value="descending" /><label
+                for="sort-desc">descending</label>
+        </fieldset>
+    </form>
+</details>
+
 <table id="cells" class="notebook-cells" role="{{resources.table_pattern.table}}" data-sort="ascending">
-    <colgroup>
-        {% for col in COLUMNS %}
-        <col class="nb-{{col}}">
-        {% endfor %}
-    </colgroup>
     <tbody role="{{resources.table_pattern.rowgroup}}" class="cells" aria-labelledby="nb-notebook-label nb-cells-label">
         <tr role="{{resources.table_pattern.row}}" hidden>
             {% for col in COLUMNS %}
@@ -101,3 +104,8 @@ the template provides the structure for new cells when they are added. #}
     </table>
 </template>
 {% endblock %}
+
+{% block footer_js %}
+{{super()}}
+{{thebe_head()}}
+{% endblock footer_js %}

--- a/nbconvert_a11y/templates/a11y/thebe.html.j2
+++ b/nbconvert_a11y/templates/a11y/thebe.html.j2
@@ -1,0 +1,35 @@
+<!-- Configure and load Thebe !-->
+
+{% macro thebe_head() %}
+<script type="text/x-thebe-config">
+{
+    requestKernel: true,
+    selector: ".code textarea[name=source]",
+    outputSelector: "fieldset.nb-outputs > div",
+    stripOutputPrompts: true,
+    binderOptions: {
+      repo: "binder-examples/requirements",
+    },
+    codeMirrorConfig: {
+        matchBrackets: true,
+    },
+    mountActivateWidget: true,
+    mountStatusWidget: true,
+    mountRunAllButton: false,
+    mountRestartButton: false,
+    mountRestartAllButton: false,
+  }
+</script>
+<script src="https://unpkg.com/thebe@latest/lib/index.js"></script>
+{% endmacro %}
+
+{% macro thebe_status() %}
+<fieldset name=kernel>
+    <div class="thebe-status" />
+</fieldset>
+{% endmacro %}
+
+{% macro thebe_activate() %}
+{# thebe replaces this #}
+<div class="thebe-activate">Activate</div>
+{% endmacro %}


### PR DESCRIPTION
this pull request introduces new inaccessibilities that need significant development and research. it is important to include this substrate to understand the interactive experience even if it is inaccessible. we can progress from here.

we use thebe as a javascript drop in for interactive execution. this tool defaults to code mirror 5 for code input which has known inaccessibilities. we'll work around them to improve the accessibility of our system.